### PR TITLE
add experimental support for notification

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -35,7 +35,8 @@ async fn main() -> Result<()> {
         dir_entries,
     };
 
-    Server::mount(mountpoint, Default::default())?
+    Server::mount(mountpoint, Default::default())
+        .await?
         .run(hello)
         .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,6 @@ pub mod session;
 pub use crate::{
     conn::MountOptions,
     dir::DirEntry,
-    server::Server,
+    server::{Notifier, Server},
     session::{Context, Filesystem, Operation},
 };

--- a/src/session/buf.rs
+++ b/src/session/buf.rs
@@ -92,7 +92,17 @@ impl Buffer {
             RequestKind::Write { arg: write_in } => {
                 let size = write_in.size as usize;
                 if offset + size < self.recv_buf.len() {
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, "receive_write"));
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, "decode: write"));
+                }
+                Some(&self.recv_buf[offset..offset + size])
+            }
+            RequestKind::NotifyReply { arg: retrieve_in } => {
+                let size = retrieve_in.size as usize;
+                if offset + size < self.recv_buf.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "decode: retrieve_in",
+                    ));
                 }
                 Some(&self.recv_buf[offset..offset + size])
             }

--- a/src/session/reply.rs
+++ b/src/session/reply.rs
@@ -11,6 +11,11 @@ use polyfuse_sys::abi::{
     fuse_getxattr_out,
     fuse_init_out,
     fuse_lk_out,
+    fuse_notify_delete_out,
+    fuse_notify_inval_entry_out,
+    fuse_notify_inval_inode_out,
+    fuse_notify_retrieve_out,
+    fuse_notify_store_out,
     fuse_open_out,
     fuse_out_header,
     fuse_statfs_out,
@@ -57,6 +62,11 @@ impl_as_ref_for_abi! {
     fuse_statfs_out,
     fuse_lk_out,
     fuse_bmap_out,
+    fuse_notify_inval_inode_out,
+    fuse_notify_inval_entry_out,
+    fuse_notify_delete_out,
+    fuse_notify_store_out,
+    fuse_notify_retrieve_out,
 }
 
 /// Reply with an empty output.


### PR DESCRIPTION
Limitations:
* There are additional allocation cost when a `FUSE_NOTIFY_REPLY` request is received and pass its payload through the sender.
