### PR TITLE
add FUSE-specific I/O abstraction

### DIFF
--- a/examples/examples/heartbeat.rs
+++ b/examples/examples/heartbeat.rs
@@ -155,7 +155,7 @@ impl<T> Filesystem<T> for Heartbeat {
     ) -> io::Result<()>
     where
         T: Send + 'async_trait,
-        W: AsyncWrite + Unpin + Send,
+        W: Writer + Unpin + Send,
     {
         match op {
             Operation::Getattr(op) => match op.ino() {

--- a/examples/examples/heartbeat_entry.rs
+++ b/examples/examples/heartbeat_entry.rs
@@ -124,7 +124,7 @@ impl<T> Filesystem<T> for Heartbeat {
     ) -> io::Result<()>
     where
         T: Send + 'async_trait,
-        W: AsyncWrite + Unpin + Send,
+        W: Writer + Unpin + Send,
     {
         match op {
             Operation::Lookup(op) => match op.parent() {

--- a/examples/examples/hello.rs
+++ b/examples/examples/hello.rs
@@ -143,7 +143,7 @@ impl<T> Filesystem<T> for Hello {
     ) -> io::Result<()>
     where
         T: Send + 'async_trait,
-        W: AsyncWrite + Unpin + Send,
+        W: Writer + Unpin + Send,
     {
         match op {
             Operation::Lookup(op) => match self.lookup(op.parent(), op.name()) {

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -5,11 +5,10 @@ pub mod memfs;
 
 pub mod prelude {
     pub use anyhow::{anyhow, ensure};
-    pub use futures::{
-        future::{Future, FutureExt},
-        io::AsyncWrite,
+    pub use futures::future::{Future, FutureExt};
+    pub use polyfuse::{
+        async_trait, io::Writer, op::Operation, reply::ReplyWriter, Context, Filesystem,
     };
-    pub use polyfuse::{async_trait, op::Operation, reply::ReplyWriter, Context, Filesystem};
     pub use std::{
         ffi::{OsStr, OsString},
         os::unix::ffi::OsStrExt,

--- a/examples/src/memfs/mod.rs
+++ b/examples/src/memfs/mod.rs
@@ -53,7 +53,7 @@ impl MemFS {
         op: op::Lookup<'_>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         match self.inodes.lookup(op.parent(), op.name()).await {
             Some(inode) => {
@@ -73,7 +73,7 @@ impl MemFS {
         op: op::Getattr<'_>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let inode = match self.inodes.get(op.ino()).await {
             Some(inode) => inode,
@@ -93,7 +93,7 @@ impl MemFS {
         op: polyfuse::op::Setattr<'_>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let inode = match self.inodes.get(op.ino()).await {
             Some(inode) => inode,
@@ -148,7 +148,7 @@ impl MemFS {
         op: op::Read<'_>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let inode = match self.inodes.get(op.ino()).await {
             Some(inode) => inode,
@@ -173,7 +173,7 @@ impl MemFS {
         data: T,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
         T: AsRef<[u8]>,
     {
         let inode = match self.inodes.get(op.ino()).await {
@@ -204,7 +204,7 @@ impl MemFS {
         op: op::Readdir<'_>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let inode = match self.inodes.get(op.ino()).await {
             Some(inode) => inode,
@@ -240,7 +240,7 @@ impl MemFS {
         op: op::Mknod<'_>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         match op.mode() & libc::S_IFMT {
             libc::S_IFREG => {
@@ -271,7 +271,7 @@ impl MemFS {
         op: op::Mkdir<'_>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let attr = self.make_attr(cx, op.mode());
         match self.inodes.insert_dir(op.parent(), op.name(), attr).await {
@@ -299,7 +299,7 @@ where
         writer: &'a mut ReplyWriter<'w, W>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Send + Unpin + 'async_trait,
+        W: Writer + Send + Unpin + 'async_trait,
         T: Send + 'async_trait,
     {
         match op {

--- a/polyfuse-tokio/Cargo.toml
+++ b/polyfuse-tokio/Cargo.toml
@@ -14,6 +14,7 @@ bytes = "0.5"
 futures = { version = "0.3.0", features = [ "unstable", "async-await" ] }
 libc = "0.2"
 mio = "0.6"
+smallvec = "0.6"
 tracing = "0.1"
 
 [dependencies.tokio]

--- a/polyfuse/src/fs.rs
+++ b/polyfuse/src/fs.rs
@@ -3,17 +3,16 @@
 use crate::{
     async_trait,
     common::Forget,
+    io::{InHeader, Writer},
     op::Operation,
     reply::ReplyWriter,
-    request::RequestHeader,
     session::{Interrupt, Session},
 };
-use futures::io::AsyncWrite;
 use std::{fmt, future::Future, io, pin::Pin};
 
 /// Contextural information about an incoming request.
 pub struct Context<'a> {
-    header: &'a RequestHeader,
+    header: &'a InHeader,
     session: &'a Session,
 }
 
@@ -24,7 +23,7 @@ impl fmt::Debug for Context<'_> {
 }
 
 impl<'a> Context<'a> {
-    pub(crate) fn new(header: &'a RequestHeader, session: &'a Session) -> Self {
+    pub(crate) fn new(header: &'a InHeader, session: &'a Session) -> Self {
         Self { header, session }
     }
 
@@ -70,7 +69,7 @@ pub trait Filesystem<T>: Sync {
     ) -> io::Result<()>
     where
         T: Send + 'async_trait,
-        W: AsyncWrite + Send + Unpin,
+        W: Writer + Send + Unpin,
     {
         Ok(())
     }
@@ -103,7 +102,7 @@ macro_rules! impl_filesystem_body {
             'cx: 'async_trait,
             'w: 'async_trait,
             T: Send + 'async_trait,
-            W: AsyncWrite + Send + Unpin + 'async_trait,
+            W: Writer + Send + Unpin + 'async_trait,
         {
             (**self).reply(cx, op, writer)
         }

--- a/polyfuse/src/io.rs
+++ b/polyfuse/src/io.rs
@@ -1,0 +1,378 @@
+//! I/O abstraction specialized for FUSE.
+
+use crate::kernel::{
+    fuse_in_header, //
+    fuse_notify_retrieve_in,
+    fuse_opcode,
+    fuse_out_header,
+    fuse_write_in,
+};
+use futures::{
+    future::Future,
+    task::{self, Poll},
+};
+use std::{convert::TryFrom, io, mem, pin::Pin};
+
+/// The reader of incoming FUSE request messages.
+///
+/// The role of this trait is similar to `AsyncRead`, except that the message data
+/// is transferred to a specific buffer instance instead of the in-memory buffer.
+///
+pub trait Reader {
+    /// The buffer holding a transferred FUSE request message.
+    type Buffer: ?Sized;
+
+    /// Receive one FUSE request message from the kernel and store it
+    /// to the buffer.
+    fn poll_receive_msg(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &mut Self::Buffer,
+    ) -> Poll<io::Result<()>>;
+}
+
+impl<R: ?Sized> Reader for &mut R
+where
+    R: Reader + Unpin,
+{
+    type Buffer = R::Buffer;
+
+    #[inline]
+    fn poll_receive_msg(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &mut Self::Buffer,
+    ) -> Poll<io::Result<()>> {
+        let me = Pin::new(&mut **self.get_mut());
+        me.poll_receive_msg(cx, buf)
+    }
+}
+
+pub(crate) trait ReaderExt: Reader {
+    fn receive_msg<'r>(
+        &'r mut self,
+        buf: &'r mut Self::Buffer,
+    ) -> ReceiveMsg<'r, Self, Self::Buffer>
+    where
+        Self: Unpin,
+    {
+        ReceiveMsg { reader: self, buf }
+    }
+}
+
+impl<R: Reader + ?Sized> ReaderExt for R {}
+
+#[must_use]
+pub(crate) struct ReceiveMsg<'r, R: ?Sized, B: ?Sized> {
+    reader: &'r mut R,
+    buf: &'r mut B,
+}
+
+impl<R: ?Sized, B: ?Sized> Future for ReceiveMsg<'_, R, B>
+where
+    R: Reader<Buffer = B> + Unpin,
+{
+    type Output = io::Result<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        let me = self.get_mut();
+        Pin::new(&mut *me.reader).poll_receive_msg(cx, &mut *me.buf)
+    }
+}
+
+/// A received FUSE message to be processed.
+///
+/// It holds the raw data for a single FUSE request message received from the kernel.
+pub trait Buffer {
+    /// The rest of the request message.
+    type Data;
+
+    /// Return a reference to `InHeader` corresponding to this request.
+    fn header(&self) -> &InHeader;
+
+    /// Extract the request message data.
+    ///
+    /// The extracted data consists of three parts: the header part,
+    /// the raw data of argument part, and additional data that may
+    /// not have been transferred from the kernel space.
+    fn extract(&mut self) -> (&InHeader, &[u8], Option<Self::Data>);
+}
+
+impl<B: ?Sized> Buffer for &mut B
+where
+    B: Buffer + Unpin,
+{
+    type Data = B::Data;
+
+    #[inline]
+    fn header(&self) -> &InHeader {
+        (**self).header()
+    }
+
+    #[inline]
+    fn extract(&mut self) -> (&InHeader, &[u8], Option<Self::Data>) {
+        (**self).extract()
+    }
+}
+
+/// The header part of FUSE request messages.
+///
+/// This type is ABI-compatible with `fuse_in_header.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct InHeader(fuse_in_header);
+
+#[doc(hidden)]
+impl AsMut<[u8]> for InHeader {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        unsafe { crate::util::as_bytes_mut(self) }
+    }
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl InHeader {
+    #[doc(hidden)]
+    pub fn len(&self) -> u32 {
+        self.0.len
+    }
+
+    #[doc(hidden)]
+    pub fn unique(&self) -> u64 {
+        self.0.unique
+    }
+
+    #[doc(hidden)]
+    pub fn opcode(&self) -> Option<fuse_opcode> {
+        fuse_opcode::try_from(self.0.opcode).ok()
+    }
+
+    #[doc(hidden)]
+    pub fn nodeid(&self) -> u64 {
+        self.0.nodeid
+    }
+
+    #[doc(hidden)]
+    pub fn uid(&self) -> u32 {
+        self.0.uid
+    }
+
+    #[doc(hidden)]
+    pub fn gid(&self) -> u32 {
+        self.0.gid
+    }
+
+    #[doc(hidden)]
+    pub fn pid(&self) -> u32 {
+        self.0.pid
+    }
+
+    /// Return the argument part length in the corresponding request message.
+    pub fn arg_len(&self) -> usize {
+        match self.opcode() {
+            Some(fuse_opcode::FUSE_WRITE) => mem::size_of::<fuse_write_in>(),
+            Some(fuse_opcode::FUSE_NOTIFY_REPLY) => mem::size_of::<fuse_notify_retrieve_in>(), // = size_of::<fuse_write_in>()
+            _ => self.len() as usize - mem::size_of::<InHeader>(),
+        }
+    }
+}
+
+/// The writer of FUSE responses and notifications.
+pub trait Writer {
+    /// Send a FUSE response or notification message to the kernel.
+    fn poll_write_msg(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        header: &OutHeader,
+        payload: &[&[u8]],
+    ) -> Poll<io::Result<()>>;
+}
+
+impl<W: ?Sized> Writer for &mut W
+where
+    W: Writer + Unpin,
+{
+    #[inline]
+    fn poll_write_msg(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        header: &OutHeader,
+        payload: &[&[u8]],
+    ) -> Poll<io::Result<()>> {
+        let me = Pin::new(&mut **self.get_mut());
+        me.poll_write_msg(cx, header, payload)
+    }
+}
+
+/// The header part of FUSE response or notification messages.
+///
+/// This type is ABI-compatible with `fuse_out_header.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct OutHeader(fuse_out_header);
+
+impl AsRef<[u8]> for OutHeader {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        unsafe { crate::util::as_bytes(self) }
+    }
+}
+
+#[allow(clippy::len_without_is_empty)]
+#[doc(hidden)]
+impl OutHeader {
+    #[inline]
+    pub fn unique(&self) -> u64 {
+        self.0.unique
+    }
+
+    #[inline]
+    pub fn error(&self) -> i32 {
+        self.0.error
+    }
+
+    #[inline]
+    pub fn len(&self) -> u32 {
+        self.0.len
+    }
+}
+
+pub(crate) trait WriterExt: Writer {
+    fn send_msg<'w, 'a>(
+        &'w mut self,
+        unique: u64,
+        error: i32,
+        data: &'w [&'a [u8]],
+    ) -> SendMsg<'w, 'a, Self> {
+        let data_len: usize = data.iter().map(|t| t.len()).sum();
+        let len = u32::try_from(mem::size_of::<fuse_out_header>() + data_len).unwrap();
+        let header = OutHeader(fuse_out_header { unique, error, len });
+
+        SendMsg {
+            writer: self,
+            header,
+            data,
+        }
+    }
+}
+
+impl<W: Writer + ?Sized> WriterExt for W {}
+
+pub(crate) struct SendMsg<'w, 'a, W: ?Sized> {
+    writer: &'w mut W,
+    header: OutHeader,
+    data: &'w [&'a [u8]],
+}
+
+impl<W: ?Sized> Future for SendMsg<'_, '_, W>
+where
+    W: Writer + Unpin,
+{
+    type Output = io::Result<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        let me = self.get_mut();
+        futures::ready!(Pin::new(&mut me.writer).poll_write_msg(cx, &me.header, &me.data))?;
+        tracing::debug!(
+            "Reply to kernel: unique={}: error={}",
+            me.header.unique(),
+            me.header.error()
+        );
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{
+        executor::block_on,
+        task::{self, Poll},
+    };
+    use std::{ops::Index, pin::Pin};
+
+    #[inline]
+    fn bytes(bytes: &[u8]) -> &[u8] {
+        bytes
+    }
+    macro_rules! b {
+        ($($b:expr),*$(,)?) => ( *bytes(&[$($b),*]) );
+    }
+
+    #[derive(Default)]
+    struct DummyWriter(Vec<u8>);
+
+    impl<I> Index<I> for DummyWriter
+    where
+        Vec<u8>: Index<I>,
+    {
+        type Output = <Vec<u8> as Index<I>>::Output;
+
+        fn index(&self, index: I) -> &Self::Output {
+            self.0.index(index)
+        }
+    }
+
+    impl Writer for DummyWriter {
+        fn poll_write_msg(
+            self: Pin<&mut Self>,
+            _: &mut task::Context<'_>,
+            out_header: &OutHeader,
+            payload: &[&[u8]],
+        ) -> Poll<io::Result<()>> {
+            let me = self.get_mut();
+            me.0.extend_from_slice(out_header.as_ref());
+            for chunk in payload {
+                me.0.extend_from_slice(chunk);
+            }
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[test]
+    fn send_msg_empty() {
+        let mut writer = DummyWriter::default();
+        block_on(writer.send_msg(42, 4, &[])).unwrap();
+        assert_eq!(writer[0..4], b![0x10, 0x00, 0x00, 0x00], "header.len");
+        assert_eq!(writer[4..8], b![0x04, 0x00, 0x00, 0x00], "header.error");
+        assert_eq!(
+            writer[8..16],
+            b![0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            "header.unique"
+        );
+    }
+
+    #[test]
+    fn send_msg_single_data() {
+        let mut writer = DummyWriter::default();
+        block_on(writer.send_msg(42, 0, &["hello".as_ref()])).unwrap();
+        assert_eq!(writer[0..4], b![0x15, 0x00, 0x00, 0x00], "header.len");
+        assert_eq!(writer[4..8], b![0x00, 0x00, 0x00, 0x00], "header.error");
+        assert_eq!(
+            writer[8..16],
+            b![0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            "header.unique"
+        );
+        assert_eq!(writer[16..], b![0x68, 0x65, 0x6c, 0x6c, 0x6f], "payload");
+    }
+
+    #[test]
+    fn send_msg_chunked_data() {
+        let payload: &[&[u8]] = &[
+            "hello, ".as_ref(), //
+            "this ".as_ref(),
+            "is a ".as_ref(),
+            "message.".as_ref(),
+        ];
+        let mut writer = DummyWriter::default();
+        block_on(writer.send_msg(26, 0, payload)).unwrap();
+        assert_eq!(writer[0..4], b![0x29, 0x00, 0x00, 0x00], "header.len");
+        assert_eq!(writer[4..8], b![0x00, 0x00, 0x00, 0x00], "header.error");
+        assert_eq!(
+            writer[8..16],
+            b![0x1a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            "header.unique"
+        );
+        assert_eq!(writer[16..], *b"hello, this is a message.", "payload");
+    }
+}

--- a/polyfuse/src/lib.rs
+++ b/polyfuse/src/lib.rs
@@ -15,17 +15,19 @@
 )]
 #![forbid(clippy::unimplemented)]
 
+pub mod io;
 pub mod notify;
 pub mod op;
 pub mod reply;
-pub mod request;
 
 mod common;
 mod dirent;
 mod fs;
 mod init;
 mod kernel;
+mod request;
 mod session;
+mod util;
 
 #[doc(inline)]
 pub use crate::{
@@ -35,7 +37,6 @@ pub use crate::{
     init::{CapabilityFlags, ConnectionInfo, SessionInitializer},
     notify::Notifier,
     op::Operation,
-    request::Buffer,
     session::{Interrupt, Session},
 };
 

--- a/polyfuse/src/notify.rs
+++ b/polyfuse/src/notify.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::needless_update)]
 
 use crate::{
+    io::{Writer, WriterExt},
     kernel::{
         fuse_notify_code, //
         fuse_notify_delete_out,
@@ -12,13 +13,12 @@ use crate::{
         fuse_notify_retrieve_out,
         fuse_notify_store_out,
     },
-    reply::{as_bytes, send_msg},
     session::Session,
+    util::as_bytes,
 };
 use futures::{
     channel::oneshot,
     future::{Fuse, FusedFuture, Future, FutureExt},
-    io::AsyncWrite,
     lock::Mutex,
 };
 use smallvec::SmallVec;
@@ -65,7 +65,7 @@ impl<T> Notifier<T> {
         len: i64,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         if session.exited() {
             return Err(io::Error::new(
@@ -97,7 +97,7 @@ impl<T> Notifier<T> {
         name: impl AsRef<OsStr>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         if session.exited() {
             return Err(io::Error::new(
@@ -136,7 +136,7 @@ impl<T> Notifier<T> {
         name: impl AsRef<OsStr>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         if session.exited() {
             return Err(io::Error::new(
@@ -171,7 +171,7 @@ impl<T> Notifier<T> {
         data: &[&[u8]],
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         if session.exited() {
             return Err(io::Error::new(
@@ -204,7 +204,7 @@ impl<T> Notifier<T> {
         size: u32,
     ) -> io::Result<RetrieveHandle<T>>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         if session.exited() {
             return Err(io::Error::new(
@@ -246,7 +246,7 @@ impl<T> Notifier<T> {
         kh: u64,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         if session.exited() {
             return Err(io::Error::new(
@@ -309,8 +309,8 @@ async fn send_notify<W: ?Sized>(
     data: &[&[u8]],
 ) -> io::Result<()>
 where
-    W: AsyncWrite + Unpin,
+    W: Writer + Unpin,
 {
     let code = unsafe { mem::transmute::<_, i32>(code) };
-    send_msg(writer, 0, code, data).await
+    writer.send_msg(0, code, data).await
 }

--- a/polyfuse/src/op.rs
+++ b/polyfuse/src/op.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     common::FileLock,
+    io::{InHeader, Writer},
     kernel::{
         fuse_access_in, //
         fuse_bmap_in,
@@ -41,9 +42,8 @@ use crate::{
         ReplyWriter,
         ReplyXattr,
     },
-    request::RequestHeader,
+    util::as_bytes,
 };
-use futures::io::AsyncWrite;
 use std::{ffi::OsStr, io, os::unix::ffi::OsStrExt};
 
 /// The kind of FUSE requests received from the kernel.
@@ -185,7 +185,7 @@ pub enum Operation<'a, T> {
 
 #[derive(Debug)]
 pub struct Lookup<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) name: &'a OsStr,
 }
 
@@ -204,18 +204,16 @@ impl<'a> Lookup<'a> {
         entry: impl AsRef<ReplyEntry>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let entry = entry.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(entry) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(entry) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Getattr<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_getattr_in,
 }
 
@@ -238,18 +236,16 @@ impl<'a> Getattr<'a> {
         attr: impl AsRef<ReplyAttr>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let attr = attr.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(attr) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(attr) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Setattr<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_setattr_in,
 }
 
@@ -321,18 +317,16 @@ impl<'a> Setattr<'a> {
         attr: impl AsRef<ReplyAttr>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let attr = attr.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(attr) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(attr) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Readlink<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
 }
 
 impl Readlink<'_> {
@@ -347,7 +341,7 @@ impl Readlink<'_> {
         value: impl AsRef<OsStr>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[value.as_ref().as_bytes()]).await
     }
@@ -355,7 +349,7 @@ impl Readlink<'_> {
 
 #[derive(Debug)]
 pub struct Symlink<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) name: &'a OsStr,
     pub(crate) link: &'a OsStr,
 }
@@ -379,18 +373,16 @@ impl<'a> Symlink<'a> {
         entry: impl AsRef<ReplyEntry>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let entry = entry.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(entry) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(entry) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Mknod<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_mknod_in,
     pub(crate) name: &'a OsStr,
 }
@@ -422,18 +414,16 @@ impl<'a> Mknod<'a> {
         entry: impl AsRef<ReplyEntry>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let entry = entry.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(entry) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(entry) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Mkdir<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_mkdir_in,
     pub(crate) name: &'a OsStr,
 }
@@ -461,18 +451,16 @@ impl<'a> Mkdir<'a> {
         entry: impl AsRef<ReplyEntry>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let entry = entry.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(entry) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(entry) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Unlink<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) name: &'a OsStr,
 }
 
@@ -487,7 +475,7 @@ impl<'a> Unlink<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -495,7 +483,7 @@ impl<'a> Unlink<'a> {
 
 #[derive(Debug)]
 pub struct Rmdir<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) name: &'a OsStr,
 }
 
@@ -510,7 +498,7 @@ impl<'a> Rmdir<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -518,7 +506,7 @@ impl<'a> Rmdir<'a> {
 
 #[derive(Debug)]
 pub struct Rename<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: RenameKind<'a>,
     pub(crate) name: &'a OsStr,
     pub(crate) newname: &'a OsStr,
@@ -571,7 +559,7 @@ impl<'a> Rename<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -579,7 +567,7 @@ impl<'a> Rename<'a> {
 
 #[derive(Debug)]
 pub struct Link<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_link_in,
     pub(crate) newname: &'a OsStr,
 }
@@ -603,18 +591,16 @@ impl<'a> Link<'a> {
         entry: impl AsRef<ReplyEntry>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let entry = entry.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(entry) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(entry) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Open<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_open_in,
 }
 
@@ -633,18 +619,16 @@ impl<'a> Open<'a> {
         out: impl AsRef<ReplyOpen>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let out = out.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(out) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(out) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Read<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_read_in,
 }
 
@@ -683,7 +667,7 @@ impl<'a> Read<'a> {
         data: impl AsRef<[u8]>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let data = data.as_ref();
 
@@ -700,7 +684,7 @@ impl<'a> Read<'a> {
         data: &[&[u8]],
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let data_len: usize = data.iter().map(|t| t.len()).sum();
         if data_len <= self.size() as usize {
@@ -713,7 +697,7 @@ impl<'a> Read<'a> {
 
 #[derive(Debug)]
 pub struct Write<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_write_in,
 }
 
@@ -752,18 +736,16 @@ impl<'a> Write<'a> {
         out: impl AsRef<ReplyWrite>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let out = out.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(out) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(out) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Release<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_release_in,
 }
 
@@ -795,7 +777,7 @@ impl<'a> Release<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -803,7 +785,7 @@ impl<'a> Release<'a> {
 
 #[derive(Debug)]
 pub struct Statfs<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
 }
 
 impl Statfs<'_> {
@@ -817,18 +799,16 @@ impl Statfs<'_> {
         out: impl AsRef<ReplyStatfs>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let out = out.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(out) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(out) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Fsync<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_fsync_in,
 }
 
@@ -847,7 +827,7 @@ impl<'a> Fsync<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -855,7 +835,7 @@ impl<'a> Fsync<'a> {
 
 #[derive(Debug)]
 pub struct Setxattr<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_setxattr_in,
     pub(crate) name: &'a OsStr,
     pub(crate) value: &'a [u8],
@@ -880,7 +860,7 @@ impl<'a> Setxattr<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -888,7 +868,7 @@ impl<'a> Setxattr<'a> {
 
 #[derive(Debug)]
 pub struct Getxattr<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_getxattr_in,
     pub(crate) name: &'a OsStr,
 }
@@ -912,12 +892,10 @@ impl<'a> Getxattr<'a> {
         out: impl AsRef<ReplyXattr>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let out = out.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(out) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(out) }]).await
     }
 
     pub async fn reply<W: ?Sized>(
@@ -926,7 +904,7 @@ impl<'a> Getxattr<'a> {
         data: impl AsRef<[u8]>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let data = data.as_ref();
 
@@ -943,7 +921,7 @@ impl<'a> Getxattr<'a> {
         data: &[&[u8]],
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let data_len: usize = data.iter().map(|t| t.len()).sum();
         if data_len <= self.size() as usize {
@@ -956,7 +934,7 @@ impl<'a> Getxattr<'a> {
 
 #[derive(Debug)]
 pub struct Listxattr<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_getxattr_in,
 }
 
@@ -975,12 +953,10 @@ impl<'a> Listxattr<'a> {
         out: impl AsRef<ReplyXattr>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let out = out.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(out) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(out) }]).await
     }
 
     pub async fn reply<W: ?Sized>(
@@ -989,7 +965,7 @@ impl<'a> Listxattr<'a> {
         data: impl AsRef<[u8]>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let data = data.as_ref();
 
@@ -1006,7 +982,7 @@ impl<'a> Listxattr<'a> {
         data: &[&[u8]],
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let data_len: usize = data.iter().map(|t| t.len()).sum();
         if data_len <= self.size() as usize {
@@ -1018,7 +994,7 @@ impl<'a> Listxattr<'a> {
 }
 #[derive(Debug)]
 pub struct Removexattr<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) name: &'a OsStr,
 }
 
@@ -1033,7 +1009,7 @@ impl<'a> Removexattr<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -1041,7 +1017,7 @@ impl<'a> Removexattr<'a> {
 
 #[derive(Debug)]
 pub struct Flush<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_flush_in,
 }
 
@@ -1060,7 +1036,7 @@ impl<'a> Flush<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -1068,7 +1044,7 @@ impl<'a> Flush<'a> {
 
 #[derive(Debug)]
 pub struct Opendir<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_open_in,
 }
 
@@ -1087,12 +1063,10 @@ impl<'a> Opendir<'a> {
         out: impl AsRef<ReplyOpendir>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let out = out.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(out) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(out) }]).await
     }
 }
 
@@ -1104,7 +1078,7 @@ pub enum ReaddirMode {
 
 #[derive(Debug)]
 pub struct Readdir<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_read_in,
     pub(crate) mode: ReaddirMode,
 }
@@ -1136,7 +1110,7 @@ impl<'a> Readdir<'a> {
         data: impl AsRef<[u8]>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let data = data.as_ref();
 
@@ -1153,7 +1127,7 @@ impl<'a> Readdir<'a> {
         data: &[&[u8]],
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let data_len: usize = data.iter().map(|t| t.len()).sum();
         if data_len <= self.size() as usize {
@@ -1166,7 +1140,7 @@ impl<'a> Readdir<'a> {
 
 #[derive(Debug)]
 pub struct Releasedir<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_release_in,
 }
 
@@ -1185,7 +1159,7 @@ impl<'a> Releasedir<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -1193,7 +1167,7 @@ impl<'a> Releasedir<'a> {
 
 #[derive(Debug)]
 pub struct Fsyncdir<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_fsync_in,
 }
 
@@ -1212,7 +1186,7 @@ impl<'a> Fsyncdir<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -1220,7 +1194,7 @@ impl<'a> Fsyncdir<'a> {
 
 #[derive(Debug)]
 pub struct Getlk<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_lk_in,
 }
 
@@ -1247,18 +1221,16 @@ impl<'a> Getlk<'a> {
         out: impl AsRef<ReplyLk>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let out = out.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(out) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(out) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Setlk<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_lk_in,
     pub(crate) sleep: bool,
 }
@@ -1286,7 +1258,7 @@ impl<'a> Setlk<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -1294,7 +1266,7 @@ impl<'a> Setlk<'a> {
 
 #[derive(Debug)]
 pub struct Flock<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_lk_in,
     pub(crate) sleep: bool,
 }
@@ -1333,7 +1305,7 @@ impl<'a> Flock<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -1341,7 +1313,7 @@ impl<'a> Flock<'a> {
 
 #[derive(Debug)]
 pub struct Access<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_access_in,
 }
 
@@ -1356,7 +1328,7 @@ impl<'a> Access<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -1364,7 +1336,7 @@ impl<'a> Access<'a> {
 
 #[derive(Debug)]
 pub struct Create<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_create_in,
     pub(crate) name: &'a OsStr,
 }
@@ -1397,14 +1369,14 @@ impl<'a> Create<'a> {
         open: impl AsRef<ReplyOpen>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let entry = entry.as_ref();
         let open = open.as_ref();
         writer
             .reply_raw(&[
-                unsafe { crate::reply::as_bytes(entry) }, //
-                unsafe { crate::reply::as_bytes(open) },
+                unsafe { as_bytes(entry) }, //
+                unsafe { as_bytes(open) },
             ])
             .await
     }
@@ -1412,7 +1384,7 @@ impl<'a> Create<'a> {
 
 #[derive(Debug)]
 pub struct Bmap<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_bmap_in,
 }
 
@@ -1435,18 +1407,16 @@ impl<'a> Bmap<'a> {
         out: impl AsRef<ReplyBmap>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let out = out.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(out) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(out) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Fallocate<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_fallocate_in,
 }
 
@@ -1473,7 +1443,7 @@ impl<'a> Fallocate<'a> {
 
     pub async fn reply<W: ?Sized>(self, writer: &mut ReplyWriter<'_, W>) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         writer.reply_raw(&[]).await
     }
@@ -1481,7 +1451,7 @@ impl<'a> Fallocate<'a> {
 
 #[derive(Debug)]
 pub struct CopyFileRange<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_copy_file_range_in,
 }
 
@@ -1508,18 +1478,16 @@ impl<'a> CopyFileRange<'a> {
         out: impl AsRef<ReplyWrite>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let out = out.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(out) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(out) }]).await
     }
 }
 
 #[derive(Debug)]
 pub struct Poll<'a> {
-    pub(crate) header: &'a RequestHeader,
+    pub(crate) header: &'a InHeader,
     pub(crate) arg: &'a fuse_poll_in,
 }
 
@@ -1550,11 +1518,9 @@ impl<'a> Poll<'a> {
         out: impl AsRef<ReplyPoll>,
     ) -> io::Result<()>
     where
-        W: AsyncWrite + Unpin,
+        W: Writer + Unpin,
     {
         let out = out.as_ref();
-        writer
-            .reply_raw(&[unsafe { crate::reply::as_bytes(out) }])
-            .await
+        writer.reply_raw(&[unsafe { as_bytes(out) }]).await
     }
 }

--- a/polyfuse/src/util.rs
+++ b/polyfuse/src/util.rs
@@ -1,0 +1,9 @@
+#[inline(always)]
+pub(crate) unsafe fn as_bytes<T: Sized>(t: &T) -> &[u8] {
+    std::slice::from_raw_parts(t as *const T as *const u8, std::mem::size_of::<T>())
+}
+
+#[inline(always)]
+pub(crate) unsafe fn as_bytes_mut<T: Sized>(t: &mut T) -> &mut [u8] {
+    std::slice::from_raw_parts_mut(t as *mut T as *mut u8, std::mem::size_of::<T>())
+}


### PR DESCRIPTION
It replaces the current `futures-io` based I/O abstraction, in order to better represent the FUSE-specific I/O operations, including `splice(2)`.

The older `request::Buffer` is removed and the `request` module becomes private.

Closes #50.