### PR TITLE
 remove (temporarily) the interrupt support

### DIFF
--- a/polyfuse/src/fs.rs
+++ b/polyfuse/src/fs.rs
@@ -6,14 +6,12 @@ use crate::{
     io::{InHeader, Writer},
     op::Operation,
     reply::ReplyWriter,
-    session::{Interrupt, Session},
 };
 use std::{fmt, future::Future, io, pin::Pin};
 
 /// Contextural information about an incoming request.
 pub struct Context<'a> {
     header: &'a InHeader,
-    session: &'a Session,
 }
 
 impl fmt::Debug for Context<'_> {
@@ -23,8 +21,8 @@ impl fmt::Debug for Context<'_> {
 }
 
 impl<'a> Context<'a> {
-    pub(crate) fn new(header: &'a InHeader, session: &'a Session) -> Self {
-        Self { header, session }
+    pub(crate) fn new(header: &'a InHeader) -> Self {
+        Self { header }
     }
 
     /// Return the user ID of the calling process.
@@ -40,12 +38,6 @@ impl<'a> Context<'a> {
     /// Return the process ID of the calling process.
     pub fn pid(&self) -> u32 {
         self.header.pid()
-    }
-
-    /// Register the request with the sesssion and get a signal
-    /// that will be notified when the request is canceld by the kernel.
-    pub async fn on_interrupt(&mut self) -> Interrupt {
-        self.session.enable_interrupt(self.header.unique()).await
     }
 }
 

--- a/polyfuse/src/session.rs
+++ b/polyfuse/src/session.rs
@@ -11,17 +11,9 @@ use crate::{
     reply::ReplyWriter,
     request::RequestKind,
 };
-use futures::{
-    channel::oneshot,
-    future::{Fuse, FusedFuture, Future, FutureExt},
-    lock::Mutex,
-};
 use std::{
-    collections::HashMap,
     io,
-    pin::Pin,
     sync::atomic::{AtomicBool, Ordering},
-    task::{self, Poll},
 };
 
 /// FUSE session driver.
@@ -30,12 +22,6 @@ pub struct Session {
     conn: ConnectionInfo,
     bufsize: usize,
     exited: AtomicBool,
-    interrupt_state: Mutex<InterruptState>,
-}
-
-#[derive(Debug)]
-struct InterruptState {
-    remains: HashMap<u64, oneshot::Sender<()>>,
 }
 
 impl Session {
@@ -44,9 +30,6 @@ impl Session {
             conn,
             bufsize,
             exited: AtomicBool::new(false),
-            interrupt_state: Mutex::new(InterruptState {
-                remains: HashMap::new(),
-            }),
         }
     }
 
@@ -74,17 +57,17 @@ impl Session {
         reader: &mut R,
         buf: &mut B,
         notifier: &Notifier<B::Data>,
-    ) -> io::Result<()>
+    ) -> io::Result<Vec<Interrupt>>
     where
         R: Reader<Buffer = B> + Unpin,
         B: Buffer + Unpin,
     {
+        let mut interrupts = vec![];
         loop {
             reader.receive_msg(buf).await?;
-
             match buf.header().opcode() {
                 Some(fuse_opcode::FUSE_INTERRUPT) | Some(fuse_opcode::FUSE_NOTIFY_REPLY) => (),
-                _ => return Ok(()),
+                _ => return Ok(interrupts),
             }
 
             let (header, kind, data) = buf.extract();
@@ -92,7 +75,10 @@ impl Session {
             match kind {
                 RequestKind::Interrupt { arg } => {
                     tracing::debug!("Receive INTERRUPT (unique = {:?})", arg.unique);
-                    self.send_interrupt(arg.unique).await;
+                    interrupts.push(Interrupt {
+                        unique: arg.unique,
+                        interrupt_unique: header.unique(),
+                    });
                 }
                 RequestKind::NotifyReply { arg } => {
                     let unique = header.unique();
@@ -135,7 +121,7 @@ impl Session {
             header.opcode(),
         );
 
-        let mut cx = Context::new(&header, &*self);
+        let mut cx = Context::new(&header);
         let mut writer = ReplyWriter::new(header.unique(), &mut *writer);
 
         macro_rules! do_reply {
@@ -346,38 +332,32 @@ impl Session {
 
         Ok(())
     }
-
-    pub(crate) async fn enable_interrupt(&self, unique: u64) -> Interrupt {
-        let (tx, rx) = oneshot::channel();
-        let mut state = self.interrupt_state.lock().await;
-        state.remains.insert(unique, tx);
-        Interrupt(rx.fuse())
-    }
-
-    async fn send_interrupt(&self, unique: u64) {
-        let mut state = self.interrupt_state.lock().await;
-        if let Some(tx) = state.remains.remove(&unique) {
-            let _ = tx.send(());
-            tracing::debug!("Sent interrupt signal to unique={}", unique);
-        }
-    }
+}
+/// Information about an interrupt request.
+#[derive(Debug, Copy, Clone)]
+pub struct Interrupt {
+    unique: u64,
+    interrupt_unique: u64,
 }
 
-/// A future for awaiting an interrupt signal sent to a request.
-#[derive(Debug)]
-pub struct Interrupt(Fuse<oneshot::Receiver<()>>);
-
-impl Future for Interrupt {
-    type Output = ();
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
-        let _res = futures::ready!(self.0.poll_unpin(cx));
-        Poll::Ready(())
+impl Interrupt {
+    /// Return the unique ID of the interrupted request.
+    ///
+    /// The implementation of FUSE filesystem deamon library should
+    /// handle this interrupt request by sending a reply with an EINTR error,
+    /// and terminate the background task processing the corresponding request.
+    #[inline]
+    pub fn unique(&self) -> u64 {
+        self.unique
     }
-}
 
-impl FusedFuture for Interrupt {
-    fn is_terminated(&self) -> bool {
-        self.0.is_terminated()
+    /// Return the unique ID of the interrupt request itself.
+    ///
+    /// If the filesystem daemon is not ready to handle this interrupt
+    /// request, sending a reply using this unique with EAGAIN error causes
+    /// the kernel to requeue its interrupt request.
+    #[inline]
+    pub fn interrupt_unique(&self) -> u64 {
+        self.interrupt_unique
     }
 }


### PR DESCRIPTION
The current implementation around handling the INTERRUPT request is incomplete and we need to reconsider a more efficient, runtime-aware way.