### PR TITLE
introduce abstraction for representing scattered bytes

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -9,7 +9,7 @@ pub mod prelude {
     pub use futures::future::{Future, FutureExt};
     pub use polyfuse::{
         async_trait,
-        io::{Reader, Writer},
+        io::{Reader, ScatteredBytes, Writer},
         op::Operation,
         Context, Filesystem,
     };
@@ -28,4 +28,27 @@ pub fn get_mountpoint() -> anyhow::Result<std::path::PathBuf> {
         .nth(1)
         .map(Into::into)
         .ok_or_else(|| anyhow::anyhow!("missing mountpoint"))
+}
+
+// FIXME: use either crate.
+pub enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+impl<L, R> polyfuse::io::ScatteredBytes for Either<L, R>
+where
+    L: polyfuse::io::ScatteredBytes,
+    R: polyfuse::io::ScatteredBytes,
+{
+    #[inline]
+    fn collect<'a, C: ?Sized>(&'a self, collector: &mut C)
+    where
+        C: polyfuse::io::Collector<'a>,
+    {
+        match self {
+            Either::Left(l) => l.collect(collector),
+            Either::Right(r) => r.collect(collector),
+        }
+    }
 }

--- a/polyfuse/src/dirent.rs
+++ b/polyfuse/src/dirent.rs
@@ -1,4 +1,7 @@
-use crate::kernel::fuse_dirent;
+use crate::{
+    io::{Collector, ScatteredBytes},
+    kernel::fuse_dirent,
+};
 use memoffset::offset_of;
 use std::{convert::TryFrom, ffi::OsStr, mem, os::unix::ffi::OsStrExt, ptr};
 
@@ -155,6 +158,16 @@ impl DirEntry {
 impl AsRef<[u8]> for DirEntry {
     fn as_ref(&self) -> &[u8] {
         self.dirent_buf.as_ref()
+    }
+}
+
+impl ScatteredBytes for DirEntry {
+    #[inline]
+    fn collect<'a, T: ?Sized>(&'a self, collector: &mut T)
+    where
+        T: Collector<'a>,
+    {
+        collector.append(self.as_ref());
     }
 }
 

--- a/polyfuse/src/init.rs
+++ b/polyfuse/src/init.rs
@@ -169,7 +169,7 @@ impl SessionInitializer {
 
                 if init_in.major > 7 {
                     tracing::debug!("wait for a second INIT request with an older version.");
-                    io.send_msg(header.unique, 0, &[unsafe { as_bytes(&init_out) }])
+                    io.send_msg(header.unique, 0, unsafe { as_bytes(&init_out) })
                         .await?;
                     return Ok(None);
                 }
@@ -181,7 +181,7 @@ impl SessionInitializer {
                         init_in.major,
                         init_in.minor
                     );
-                    io.send_msg(header.unique, -libc::EPROTO, &[]).await?;
+                    io.send_msg(header.unique, -libc::EPROTO, &()).await?;
                     return Ok(None);
                 }
 
@@ -222,7 +222,7 @@ impl SessionInitializer {
                     init_out.congestion_threshold
                 );
                 tracing::debug!("  time_gran = {}", init_out.time_gran);
-                io.send_msg(header.unique, 0, &[unsafe { as_bytes(&init_out) }])
+                io.send_msg(header.unique, 0, unsafe { as_bytes(&init_out) })
                     .await?;
 
                 init_out.flags |= readonly_flags;
@@ -237,7 +237,7 @@ impl SessionInitializer {
                     "ignoring an operation before init (opcode={:?})",
                     header.opcode
                 );
-                io.send_msg(header.unique, -libc::EIO, &[]).await?;
+                io.send_msg(header.unique, -libc::EIO, &()).await?;
                 Ok(None)
             }
         }

--- a/polyfuse/src/io.rs
+++ b/polyfuse/src/io.rs
@@ -19,9 +19,11 @@ use pin_project_lite::pin_project;
 use smallvec::SmallVec;
 use std::{
     convert::TryFrom,
+    ffi::{OsStr, OsString},
     io::{self, IoSlice, IoSliceMut},
     mem,
     ops::DerefMut,
+    os::unix::ffi::OsStrExt,
     pin::Pin,
 };
 
@@ -183,23 +185,44 @@ where
 impl Writer for Vec<u8> {}
 
 pub(crate) trait WriterExt: Writer {
-    fn send_msg<'w>(
+    fn send_msg<'w, T: ?Sized>(
         &'w mut self,
         unique: u64,
         error: i32,
-        data: &'w [&'w [u8]],
+        data: &'w T,
     ) -> SendMsg<'w, Self>
     where
         Self: Unpin,
+        T: ScatteredBytes,
     {
-        let data_len: usize = data.iter().map(|t| t.len()).sum();
-        let len = u32::try_from(mem::size_of::<fuse_out_header>() + data_len).unwrap();
+        struct VecCollector<'a, 'v> {
+            vec: &'v mut Vec<&'a [u8]>,
+            total_len: usize,
+        }
+
+        impl<'a> Collector<'a> for VecCollector<'a, '_> {
+            fn append(&mut self, bytes: &'a [u8]) {
+                self.vec.push(bytes);
+                self.total_len += bytes.len();
+            }
+        }
+
+        let mut vec = Vec::new();
+        let mut collector = VecCollector {
+            vec: &mut vec,
+            total_len: 0,
+        };
+        data.collect(&mut collector);
+
+        let len = u32::try_from(mem::size_of::<fuse_out_header>() + collector.total_len).unwrap();
         let header = fuse_out_header { unique, error, len };
+
+        drop(collector);
 
         SendMsg {
             writer: self,
             header,
-            data,
+            vec,
         }
     }
 }
@@ -209,7 +232,7 @@ impl<W: Writer + ?Sized> WriterExt for W {}
 pub(crate) struct SendMsg<'w, W: ?Sized> {
     writer: &'w mut W,
     header: fuse_out_header,
-    data: &'w [&'w [u8]],
+    vec: Vec<&'w [u8]>,
 }
 
 impl<W: ?Sized> Future for SendMsg<'_, W>
@@ -226,7 +249,7 @@ where
         let vec: SmallVec<[_; 4]> =
             Some(IoSlice::new(unsafe { crate::util::as_bytes(&me.header) }))
                 .into_iter()
-                .chain(me.data.iter().map(|t| IoSlice::new(&*t)))
+                .chain(me.vec.iter().map(|t| IoSlice::new(&*t)))
                 .collect();
 
         let count = futures::ready!(Pin::new(&mut *me.writer).poll_write_vectored(cx, &*vec))?;
@@ -320,6 +343,204 @@ where
 impl<R, W> Reader for Unite<R, W> where R: Reader {}
 
 impl<R, W> Writer for Unite<R, W> where W: Writer {}
+
+/// Data structure which consists of *scattered* bytes.
+pub trait ScatteredBytes {
+    /// Collect the scattered bytes in the `collector`.
+    fn collect<'a, T: ?Sized>(&'a self, collector: &mut T)
+    where
+        T: Collector<'a>;
+}
+
+// ==== pointer types ====
+
+macro_rules! impl_scattered_bytes_body_for_pointers {
+    () => {
+        #[inline]
+        fn collect<'a, T: ?Sized>(&'a self, collector: &mut T)
+        where
+            T: Collector<'a>,
+        {
+            (**self).collect(collector)
+        }
+    }
+}
+
+impl<R: ?Sized> ScatteredBytes for &R
+where
+    R: ScatteredBytes,
+{
+    impl_scattered_bytes_body_for_pointers!();
+}
+
+impl<R: ?Sized> ScatteredBytes for &mut R
+where
+    R: ScatteredBytes,
+{
+    impl_scattered_bytes_body_for_pointers!();
+}
+
+impl<R: ?Sized> ScatteredBytes for Box<R>
+where
+    R: ScatteredBytes,
+{
+    impl_scattered_bytes_body_for_pointers!();
+}
+
+impl<R: ?Sized> ScatteredBytes for std::rc::Rc<R>
+where
+    R: ScatteredBytes,
+{
+    impl_scattered_bytes_body_for_pointers!();
+}
+
+impl<R: ?Sized> ScatteredBytes for std::sync::Arc<R>
+where
+    R: ScatteredBytes,
+{
+    impl_scattered_bytes_body_for_pointers!();
+}
+
+// ==== empty bytes ====
+
+impl ScatteredBytes for () {
+    #[inline]
+    fn collect<'a, T: ?Sized>(&'a self, _: &mut T)
+    where
+        T: Collector<'a>,
+    {
+    }
+}
+
+impl ScatteredBytes for [u8; 0] {
+    #[inline]
+    fn collect<'a, T: ?Sized>(&'a self, _: &mut T)
+    where
+        T: Collector<'a>,
+    {
+    }
+}
+
+// ==== compound types ====
+
+macro_rules! impl_scattered_bytes_for_tuple {
+    ($($T:ident),+ $(,)?) => {
+        impl<$($T),+> ScatteredBytes for ($($T,)+)
+        where
+            $( $T: ScatteredBytes, )+
+        {
+            #[allow(nonstandard_style)]
+            #[inline]
+            fn collect<'a, T: ?Sized>(&'a self, collector: &mut T)
+            where
+                T: Collector<'a>,
+            {
+                let ($($T,)+) = self;
+                $(
+                    $T.collect(collector);
+                )+
+            }
+        }
+    }
+}
+
+impl_scattered_bytes_for_tuple!(T1);
+impl_scattered_bytes_for_tuple!(T1, T2);
+impl_scattered_bytes_for_tuple!(T1, T2, T3);
+impl_scattered_bytes_for_tuple!(T1, T2, T3, T4);
+impl_scattered_bytes_for_tuple!(T1, T2, T3, T4, T5);
+
+impl<R> ScatteredBytes for [R]
+where
+    R: ScatteredBytes,
+{
+    #[inline]
+    fn collect<'a, T: ?Sized>(&'a self, collector: &mut T)
+    where
+        T: Collector<'a>,
+    {
+        for t in self {
+            t.collect(collector);
+        }
+    }
+}
+
+impl<R> ScatteredBytes for Vec<R>
+where
+    R: ScatteredBytes,
+{
+    #[inline]
+    fn collect<'a, T: ?Sized>(&'a self, collector: &mut T)
+    where
+        T: Collector<'a>,
+    {
+        for t in self {
+            t.collect(collector);
+        }
+    }
+}
+
+// ==== continuous bytes ====
+
+mod impl_scattered_bytes_for_cont {
+    use super::*;
+
+    #[inline(always)]
+    fn as_bytes(t: &(impl AsRef<[u8]> + ?Sized)) -> &[u8] {
+        t.as_ref()
+    }
+
+    macro_rules! impl_scattered_bytes {
+        ($($t:ty),*$(,)?) => {$(
+            impl ScatteredBytes for $t {
+                #[inline]
+                fn collect<'a, T: ?Sized>(&'a self, collector: &mut T)
+                where
+                    T: Collector<'a>,
+                {
+                    let this = as_bytes(self);
+                    if !this.is_empty() {
+                        collector.append(this);
+                    }
+                }
+            }
+        )*};
+    }
+
+    impl_scattered_bytes! {
+        [u8],
+        str,
+        String,
+        Vec<u8>,
+        std::borrow::Cow<'_, [u8]>,
+    }
+}
+
+impl ScatteredBytes for OsStr {
+    #[inline]
+    fn collect<'a, T: ?Sized>(&'a self, collector: &mut T)
+    where
+        T: Collector<'a>,
+    {
+        self.as_bytes().collect(collector)
+    }
+}
+
+impl ScatteredBytes for OsString {
+    #[inline]
+    fn collect<'a, T: ?Sized>(&'a self, collector: &mut T)
+    where
+        T: Collector<'a>,
+    {
+        self.as_bytes().collect(collector)
+    }
+}
+
+/// Container for collecting the scattered bytes.
+pub trait Collector<'a> {
+    /// Append a chunk of bytes into itself.
+    fn append(&mut self, buf: &'a [u8]);
+}
 
 #[cfg(test)]
 mod tests {
@@ -478,7 +699,7 @@ mod tests {
     #[test]
     fn send_msg_single_data() {
         let mut writer = DummyWriter::default();
-        block_on(writer.send_msg(42, 0, &["hello".as_ref()])).unwrap();
+        block_on(writer.send_msg(42, 0, "hello")).unwrap();
         assert_eq!(writer[0..4], b![0x15, 0x00, 0x00, 0x00], "header.len");
         assert_eq!(writer[4..8], b![0x00, 0x00, 0x00, 0x00], "header.error");
         assert_eq!(

--- a/polyfuse/src/op.rs
+++ b/polyfuse/src/op.rs
@@ -47,7 +47,7 @@ use crate::{
         ReplyWrite,
         ReplyXattr,
     },
-    util::{as_bytes, make_system_time},
+    util::make_system_time,
 };
 use std::{
     convert::TryFrom, //
@@ -139,8 +139,7 @@ impl<'a> Lookup<'a> {
     where
         T: Writer + Unpin,
     {
-        let entry = entry.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(entry) }]).await
+        cx.reply_bytes(entry.as_ref()).await
     }
 }
 
@@ -178,8 +177,7 @@ impl<'a> Getattr<'a> {
     where
         T: Writer + Unpin,
     {
-        let attr = attr.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(attr) }]).await
+        cx.reply_bytes(attr.as_ref()).await
     }
 }
 
@@ -312,8 +310,7 @@ impl<'a> Setattr<'a> {
     where
         T: Writer + Unpin,
     {
-        let attr = attr.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(attr) }]).await
+        cx.reply_bytes(attr.as_ref()).await
     }
 }
 
@@ -338,7 +335,7 @@ impl Readlink<'_> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[value.as_ref().as_bytes()]).await
+        cx.reply_bytes(value.as_ref()).await
     }
 }
 
@@ -379,8 +376,7 @@ impl<'a> Symlink<'a> {
     where
         T: Writer + Unpin,
     {
-        let entry = entry.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(entry) }]).await
+        cx.reply_bytes(entry.as_ref()).await
     }
 }
 
@@ -435,8 +431,7 @@ impl<'a> Mknod<'a> {
     where
         T: Writer + Unpin,
     {
-        let entry = entry.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(entry) }]).await
+        cx.reply_bytes(entry.as_ref()).await
     }
 }
 
@@ -483,8 +478,7 @@ impl<'a> Mkdir<'a> {
     where
         T: Writer + Unpin,
     {
-        let entry = entry.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(entry) }]).await
+        cx.reply_bytes(entry.as_ref()).await
     }
 }
 
@@ -516,7 +510,7 @@ impl<'a> Unlink<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -548,7 +542,7 @@ impl<'a> Rmdir<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -622,7 +616,7 @@ impl<'a> Rename<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -662,8 +656,7 @@ impl<'a> Link<'a> {
     where
         T: Writer + Unpin,
     {
-        let entry = entry.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(entry) }]).await
+        cx.reply_bytes(entry.as_ref()).await
     }
 }
 
@@ -711,8 +704,7 @@ impl<'a> Open<'a> {
     where
         T: Writer + Unpin,
     {
-        let out = out.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(out) }]).await
+        cx.reply_bytes(out.as_ref()).await
     }
 }
 
@@ -785,7 +777,7 @@ impl<'a> Read<'a> {
         let data = data.as_ref();
 
         if data.len() <= self.size() as usize {
-            cx.reply_raw(&[data]).await
+            cx.reply_bytes(data).await
         } else {
             cx.reply_err(libc::ERANGE).await
         }
@@ -803,7 +795,7 @@ impl<'a> Read<'a> {
     {
         let data_len: usize = data.iter().map(|t| t.len()).sum();
         if data_len <= self.size() as usize {
-            cx.reply_raw(data).await
+            cx.reply_bytes(data).await
         } else {
             cx.reply_err(libc::ERANGE).await
         }
@@ -874,8 +866,7 @@ impl<'a> Write<'a> {
     where
         T: Writer + Unpin,
     {
-        let out = out.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(out) }]).await
+        cx.reply_bytes(out.as_ref()).await
     }
 }
 
@@ -930,7 +921,7 @@ impl<'a> Release<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -957,8 +948,7 @@ impl Statfs<'_> {
     where
         T: Writer + Unpin,
     {
-        let out = out.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(out) }]).await
+        cx.reply_bytes(out.as_ref()).await
     }
 }
 
@@ -993,7 +983,7 @@ impl<'a> Fsync<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -1037,7 +1027,7 @@ impl<'a> Setxattr<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -1076,8 +1066,7 @@ impl<'a> Getxattr<'a> {
     where
         T: Writer + Unpin,
     {
-        let out = out.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(out) }]).await
+        cx.reply_bytes(out.as_ref()).await
     }
 
     /// Reply with the content of the attribute value.
@@ -1092,7 +1081,7 @@ impl<'a> Getxattr<'a> {
         let data = data.as_ref();
 
         if data.len() <= self.size() as usize {
-            cx.reply_raw(&[data]).await
+            cx.reply_bytes(data).await
         } else {
             cx.reply_err(libc::ERANGE).await
         }
@@ -1109,7 +1098,7 @@ impl<'a> Getxattr<'a> {
     {
         let data_len: usize = data.iter().map(|t| t.len()).sum();
         if data_len <= self.size() as usize {
-            cx.reply_raw(data).await
+            cx.reply_bytes(data).await
         } else {
             cx.reply_err(libc::ERANGE).await
         }
@@ -1145,8 +1134,7 @@ impl<'a> Listxattr<'a> {
     where
         T: Writer + Unpin,
     {
-        let out = out.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(out) }]).await
+        cx.reply_bytes(out.as_ref()).await
     }
 
     /// Reply with the content of the attribute names.
@@ -1163,7 +1151,7 @@ impl<'a> Listxattr<'a> {
         let data = data.as_ref();
 
         if data.len() <= self.size() as usize {
-            cx.reply_raw(&[data]).await
+            cx.reply_bytes(data).await
         } else {
             cx.reply_err(libc::ERANGE).await
         }
@@ -1180,7 +1168,7 @@ impl<'a> Listxattr<'a> {
     {
         let data_len: usize = data.iter().map(|t| t.len()).sum();
         if data_len <= self.size() as usize {
-            cx.reply_raw(data).await
+            cx.reply_bytes(data).await
         } else {
             cx.reply_err(libc::ERANGE).await
         }
@@ -1213,7 +1201,7 @@ impl<'a> Removexattr<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -1254,7 +1242,7 @@ impl<'a> Flush<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -1288,8 +1276,7 @@ impl<'a> Opendir<'a> {
     where
         T: Writer + Unpin,
     {
-        let out = out.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(out) }]).await
+        cx.reply_bytes(out.as_ref()).await
     }
 }
 
@@ -1347,7 +1334,7 @@ impl<'a> Readdir<'a> {
         let data = data.as_ref();
 
         if data.len() <= self.size() as usize {
-            cx.reply_raw(&[data]).await
+            cx.reply_bytes(data).await
         } else {
             cx.reply_err(libc::ERANGE).await
         }
@@ -1365,7 +1352,7 @@ impl<'a> Readdir<'a> {
     {
         let data_len: usize = data.iter().map(|t| t.len()).sum();
         if data_len <= self.size() as usize {
-            cx.reply_raw(data).await
+            cx.reply_bytes(data).await
         } else {
             cx.reply_err(libc::ERANGE).await
         }
@@ -1404,7 +1391,7 @@ impl<'a> Releasedir<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -1439,7 +1426,7 @@ impl<'a> Fsyncdir<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -1480,8 +1467,7 @@ impl<'a> Getlk<'a> {
     where
         T: Writer + Unpin,
     {
-        let out = out.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(out) }]).await
+        cx.reply_bytes(out.as_ref()).await
     }
 }
 
@@ -1530,7 +1516,7 @@ impl<'a> Setlk<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -1588,7 +1574,7 @@ impl<'a> Flock<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -1615,7 +1601,7 @@ impl<'a> Access<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -1679,13 +1665,7 @@ impl<'a> Create<'a> {
     where
         T: Writer + Unpin,
     {
-        let entry = entry.as_ref();
-        let open = open.as_ref();
-        cx.reply_raw(&[
-            unsafe { as_bytes(entry) }, //
-            unsafe { as_bytes(open) },
-        ])
-        .await
+        cx.reply_bytes((entry.as_ref(), open.as_ref())).await
     }
 }
 
@@ -1725,8 +1705,7 @@ impl<'a> Bmap<'a> {
     where
         T: Writer + Unpin,
     {
-        let out = out.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(out) }]).await
+        cx.reply_bytes(out.as_ref()).await
     }
 }
 
@@ -1782,7 +1761,7 @@ impl<'a> Fallocate<'a> {
     where
         T: Writer + Unpin,
     {
-        cx.reply_raw(&[]).await
+        cx.reply_bytes(()).await
     }
 }
 
@@ -1870,8 +1849,7 @@ impl<'a> CopyFileRange<'a> {
     where
         T: Writer + Unpin,
     {
-        let out = out.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(out) }]).await
+        cx.reply_bytes(out.as_ref()).await
     }
 }
 
@@ -1923,8 +1901,7 @@ impl<'a> Poll<'a> {
     where
         T: Writer + Unpin,
     {
-        let out = out.as_ref();
-        cx.reply_raw(&[unsafe { as_bytes(out) }]).await
+        cx.reply_bytes(out.as_ref()).await
     }
 }
 

--- a/polyfuse/src/reply.rs
+++ b/polyfuse/src/reply.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     common::{FileAttr, FileLock, StatFs},
+    io::{Collector, ScatteredBytes},
     kernel::{
         fuse_attr_out, //
         fuse_bmap_out,
@@ -17,6 +18,32 @@ use crate::{
     },
 };
 use std::time::Duration;
+
+macro_rules! impl_scattered_buf {
+    ($($t:ty),*$(,)?) => {$(
+        impl ScatteredBytes for $t {
+            #[inline]
+            fn collect<'a, T: ?Sized>(&'a self, collector: &mut T)
+            where
+                T: Collector<'a>,
+            {
+                collector.append(unsafe { crate::util::as_bytes(self) })
+            }
+        }
+    )*};
+}
+
+impl_scattered_buf! {
+    ReplyAttr,
+    ReplyEntry,
+    ReplyOpen,
+    ReplyWrite,
+    ReplyXattr,
+    ReplyStatfs,
+    ReplyBmap,
+    ReplyLk,
+    ReplyPoll,
+}
 
 /// Reply with the inode attributes.
 #[derive(Debug)]

--- a/polyfuse/src/session.rs
+++ b/polyfuse/src/session.rs
@@ -114,9 +114,7 @@ impl Session {
                         let mut st = StatFs::default();
                         st.set_namelen(255);
                         st.set_bsize(512);
-                        let out = crate::reply::ReplyStatfs::new(st);
-                        cx.reply_raw(&[unsafe { crate::util::as_bytes(&out) }])
-                            .await?;
+                        cx.reply_bytes(crate::reply::ReplyStatfs::new(st)).await?;
                     }
                 }
                 op => {


### PR DESCRIPTION
The new trait `ScatteredBytes` is introduced in the `io` module for abstracting the discontinuous chunks of byte data.