### PR TITLE
improve the fmt::Debug implementations in public types

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,6 +18,7 @@ nix = "0.16"
 pico-args = "0.3"
 slab = "0.4"
 tracing = "0.1"
+tracing-futures = "0.2"
 tracing-subscriber = "0.1"
 
 polyfuse = { path = "../polyfuse" }

--- a/polyfuse/src/common.rs
+++ b/polyfuse/src/common.rs
@@ -7,9 +7,28 @@ use std::{convert::TryFrom, error, fmt, time::SystemTime};
 /// Attributes about a file.
 ///
 /// This type is ABI-compatible with `fuse_attr`.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Default, Clone, Copy)]
 #[repr(transparent)]
 pub struct FileAttr(fuse_attr);
+
+impl fmt::Debug for FileAttr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileAttr")
+            .field("ino", &self.ino())
+            .field("size", &self.size())
+            .field("mode", &self.mode())
+            .field("nlink", &self.nlink())
+            .field("uid", &self.uid())
+            .field("gid", &self.gid())
+            .field("rdev", &self.rdev())
+            .field("blksize", &self.blksize())
+            .field("blocks", &self.blocks())
+            .field("atime", &self.atime())
+            .field("mtime", &self.mtime())
+            .field("ctime", &self.ctime())
+            .finish()
+    }
+}
 
 impl FileAttr {
     /// Return the inode number.
@@ -200,9 +219,20 @@ impl FileAttr {
 /// File lock information.
 ///
 /// This type is ABI-compatible with `fuse_file_lock`.
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Copy, Clone, Default)]
 #[repr(transparent)]
 pub struct FileLock(fuse_file_lock);
+
+impl fmt::Debug for FileLock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileLock")
+            .field("typ", &self.typ())
+            .field("start", &self.start())
+            .field("end", &self.end())
+            .field("pid", &self.pid())
+            .finish()
+    }
+}
 
 impl FileLock {
     pub(crate) fn new(attr: &fuse_file_lock) -> &Self {
@@ -314,9 +344,24 @@ impl error::Error for InvalidFileLock {}
 /// Filesystem statistics.
 ///
 /// This type is ABI-compatible with `fuse_kstatfs`.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Clone, Copy, Default)]
 #[repr(transparent)]
 pub struct StatFs(fuse_kstatfs);
+
+impl fmt::Debug for StatFs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Statfs")
+            .field("bsize", &self.bsize())
+            .field("frsize", &self.frsize())
+            .field("blocks", &self.blocks())
+            .field("bfree", &self.bfree())
+            .field("bavail", &self.bavail())
+            .field("files", &self.files())
+            .field("ffree", &self.ffree())
+            .field("namelen", &self.namelen())
+            .finish()
+    }
+}
 
 impl StatFs {
     /// Return the block size.
@@ -426,9 +471,17 @@ impl TryFrom<libc::statvfs> for StatFs {
 /// A forget information.
 ///
 /// This type is ABI-compatible with `fuse_forget_one`.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct Forget(fuse_forget_one);
+
+impl fmt::Debug for Forget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Forget")
+            .field("ino", &self.ino())
+            .field("nlookup", &self.nlookup())
+            .finish()
+    }
+}
 
 impl Forget {
     pub(crate) const fn new(ino: u64, nlookup: u64) -> Self {

--- a/polyfuse/src/context.rs
+++ b/polyfuse/src/context.rs
@@ -14,7 +14,13 @@ pub struct Context<'cx, T: ?Sized> {
 
 impl<T: ?Sized> fmt::Debug for Context<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Context").finish()
+        f.debug_struct("Context")
+            .field("unique", &self.unique())
+            .field("uid", &self.uid())
+            .field("gid", &self.gid())
+            .field("pid", &self.pid())
+            .field("replied", &self.replied())
+            .finish()
     }
 }
 

--- a/polyfuse/src/dirent.rs
+++ b/polyfuse/src/dirent.rs
@@ -3,16 +3,26 @@ use crate::{
     reply::{Collector, Reply},
 };
 use memoffset::offset_of;
-use std::{convert::TryFrom, ffi::OsStr, mem, os::unix::ffi::OsStrExt, ptr};
+use std::{convert::TryFrom, ffi::OsStr, fmt, mem, os::unix::ffi::OsStrExt, ptr};
 
 fn aligned(len: usize) -> usize {
     (len + mem::size_of::<u64>() - 1) & !(mem::size_of::<u64>() - 1)
 }
 
 /// A directory entry replied to the kernel.
-#[derive(Debug)]
 pub struct DirEntry {
     dirent_buf: Vec<u8>,
+}
+
+impl fmt::Debug for DirEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DirEntry")
+            .field("nodeid", &self.nodeid())
+            .field("offset", &self.offset())
+            .field("typ", &self.typ())
+            .field("name", &self.name())
+            .finish()
+    }
 }
 
 impl DirEntry {

--- a/polyfuse/src/init.rs
+++ b/polyfuse/src/init.rs
@@ -18,11 +18,11 @@ use crate::{
     },
     op::OperationKind,
     session::Session,
-    util::as_bytes,
+    util::{as_bytes, BuilderExt},
 };
 use bitflags::bitflags;
 use lazy_static::lazy_static;
-use std::{cmp, io};
+use std::{cmp, fmt, io};
 
 // The minimum supported ABI minor version by polyfuse.
 const MINIMUM_SUPPORTED_MINOR_VERSION: u32 = 23;
@@ -245,8 +245,25 @@ impl SessionInitializer {
 }
 
 /// Information about the connection associated with a session.
-#[derive(Debug)]
 pub struct ConnectionInfo(fuse_init_out);
+
+impl fmt::Debug for ConnectionInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectionInfo")
+            .field("proto_major", &self.proto_major())
+            .field("proto_minor", &self.proto_minor())
+            .field("flags", &self.flags())
+            .field("no_open_support", &self.no_open_support())
+            .field("no_opendir_support", &self.no_opendir_support())
+            .field("max_readahead", &self.max_readahead())
+            .field("max_write", &self.max_write())
+            .field("max_background", &self.max_background())
+            .field("congestion_threshold", &self.congestion_threshold())
+            .field("time_gran", &self.time_gran())
+            .if_some(self.max_pages(), |f, pages| f.field("max_pages", &pages))
+            .finish()
+    }
+}
 
 impl ConnectionInfo {
     /// Returns the major version of the protocol.

--- a/polyfuse/src/io.rs
+++ b/polyfuse/src/io.rs
@@ -151,7 +151,6 @@ where
     }
 }
 
-#[derive(Debug)]
 pub(crate) struct Request {
     header: fuse_in_header,
     arg: Vec<u8>,
@@ -258,12 +257,6 @@ where
                 "written data is too short",
             )));
         }
-
-        tracing::debug!(
-            "Reply to kernel: unique={}: error={}",
-            me.header.unique,
-            me.header.error
-        );
 
         Poll::Ready(Ok(()))
     }

--- a/polyfuse/src/kernel.rs
+++ b/polyfuse/src/kernel.rs
@@ -109,7 +109,7 @@ pub const FUSE_FSYNC_FDATASYNC: u32 = 1 << 0;
 // pub const FUSE_COMPAT_22_INIT_OUT_SIZE: usize = 24;
 // pub const CUSE_INIT_INFO_MAX: u32 = 4096;
 
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Copy, Clone)]
 #[repr(C)]
 pub struct fuse_attr {
     pub ino: u64,
@@ -130,7 +130,7 @@ pub struct fuse_attr {
     pub padding: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_dirent {
     pub ino: u64,
@@ -140,14 +140,14 @@ pub struct fuse_dirent {
     pub name: [u8; 0],
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_direntplus {
     pub entry_out: fuse_entry_out,
     pub dirent: fuse_dirent,
 }
 
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default, Copy, Clone)]
 #[repr(C)]
 pub struct fuse_kstatfs {
     pub blocks: u64,
@@ -162,7 +162,7 @@ pub struct fuse_kstatfs {
     pub spare: [u32; 6usize],
 }
 
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default, Copy, Clone)]
 #[repr(C)]
 pub struct fuse_file_lock {
     pub start: u64,
@@ -181,7 +181,7 @@ macro_rules! define_opcode {
             pub const $VARIANT: u32 = $val;
         )*
 
-        #[derive(Debug, Copy, Clone, PartialEq, Hash)]
+        #[derive(Copy, Clone, PartialEq, Hash)]
         #[repr(u32)]
         pub enum fuse_opcode {
             $(
@@ -269,7 +269,6 @@ impl fmt::Display for UnknownOpcode {
 
 impl error::Error for UnknownOpcode {}
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_in_header {
     pub len: u32,
@@ -282,7 +281,6 @@ pub struct fuse_in_header {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_init_in {
     pub major: u32,
@@ -291,13 +289,11 @@ pub struct fuse_init_in {
     pub flags: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_forget_in {
     pub nlookup: u64,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_getattr_in {
     pub getattr_flags: u32,
@@ -305,7 +301,6 @@ pub struct fuse_getattr_in {
     pub fh: u64,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_setattr_in {
     pub valid: u32,
@@ -326,7 +321,6 @@ pub struct fuse_setattr_in {
     pub unused5: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_mknod_in {
     pub mode: u32,
@@ -335,33 +329,28 @@ pub struct fuse_mknod_in {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_mkdir_in {
     pub mode: u32,
     pub umask: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_rename_in {
     pub newdir: u64,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_link_in {
     pub oldnodeid: u64,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_open_in {
     pub flags: u32,
     pub unused: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_read_in {
     pub fh: u64,
@@ -373,7 +362,6 @@ pub struct fuse_read_in {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_write_in {
     pub fh: u64,
@@ -385,7 +373,6 @@ pub struct fuse_write_in {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_flush_in {
     pub fh: u64,
@@ -394,7 +381,6 @@ pub struct fuse_flush_in {
     pub lock_owner: u64,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_release_in {
     pub fh: u64,
@@ -403,7 +389,6 @@ pub struct fuse_release_in {
     pub lock_owner: u64,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_fsync_in {
     pub fh: u64,
@@ -411,21 +396,18 @@ pub struct fuse_fsync_in {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_getxattr_in {
     pub size: u32,
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_setxattr_in {
     pub size: u32,
     pub flags: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_lk_in {
     pub fh: u64,
@@ -435,7 +417,6 @@ pub struct fuse_lk_in {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_access_in {
     pub mask: u32,
@@ -443,7 +424,6 @@ pub struct fuse_access_in {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_create_in {
     pub flags: u32,
@@ -452,7 +432,6 @@ pub struct fuse_create_in {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_bmap_in {
     pub block: u64,
@@ -460,7 +439,7 @@ pub struct fuse_bmap_in {
     pub padding: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_out_header {
     pub len: u32,
@@ -468,7 +447,7 @@ pub struct fuse_out_header {
     pub unique: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_attr_out {
     pub attr_valid: u64,
@@ -477,7 +456,7 @@ pub struct fuse_attr_out {
     pub attr: fuse_attr,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_entry_out {
     pub nodeid: u64,
@@ -489,7 +468,6 @@ pub struct fuse_entry_out {
     pub attr: fuse_attr,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_init_out {
     pub major: u32,
@@ -523,14 +501,14 @@ impl Default for fuse_init_out {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_getxattr_out {
     pub size: u32,
     pub padding: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_open_out {
     pub fh: u64,
@@ -538,43 +516,42 @@ pub struct fuse_open_out {
     pub padding: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_write_out {
     pub size: u32,
     pub padding: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_statfs_out {
     pub st: fuse_kstatfs,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_lk_out {
     pub lk: fuse_file_lock,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_bmap_out {
     pub block: u64,
 }
 
-#[derive(Debug)]
-#[repr(C)]
-pub struct fuse_ioctl_in {
-    pub fh: u64,
-    pub flags: u32,
-    pub cmd: u32,
-    pub arg: u64,
-    pub in_size: u32,
-    pub out_size: u32,
-}
+// #[repr(C)]
+// pub struct fuse_ioctl_in {
+//     pub fh: u64,
+//     pub flags: u32,
+//     pub cmd: u32,
+//     pub arg: u64,
+//     pub in_size: u32,
+//     pub out_size: u32,
+// }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_ioctl_out {
     pub result: i32,
@@ -583,14 +560,13 @@ pub struct fuse_ioctl_out {
     pub out_iovs: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_ioctl_iovec {
     pub base: u64,
     pub len: u64,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_poll_in {
     pub fh: u64,
@@ -599,7 +575,7 @@ pub struct fuse_poll_in {
     pub events: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_poll_out {
     pub revents: u32,
@@ -607,13 +583,11 @@ pub struct fuse_poll_out {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_interrupt_in {
     pub unique: u64,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_fallocate_in {
     pub fh: u64,
@@ -623,21 +597,18 @@ pub struct fuse_fallocate_in {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_batch_forget_in {
     pub count: u32,
     pub dummy: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_forget_one {
     pub nodeid: u64,
     pub nlookup: u64,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_rename2_in {
     pub newdir: u64,
@@ -645,22 +616,20 @@ pub struct fuse_rename2_in {
     pub padding: u32,
 }
 
-#[derive(Debug)]
-#[repr(C)]
-pub struct fuse_lseek_in {
-    pub fh: u64,
-    pub offset: u64,
-    pub whence: u32,
-    pub padding: u32,
-}
+// #[repr(C)]
+// pub struct fuse_lseek_in {
+//     pub fh: u64,
+//     pub offset: u64,
+//     pub whence: u32,
+//     pub padding: u32,
+// }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_lseek_out {
     pub offset: u64,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_copy_file_range_in {
     pub fh_in: u64,
@@ -682,7 +651,7 @@ macro_rules! define_notify_code {
             pub const $VARIANT: u32 = $val;
         )*
 
-        #[derive(Debug, Copy, Clone, PartialEq, Hash)]
+        #[derive(Copy, Clone, PartialEq, Hash)]
         #[repr(u32)]
         pub enum fuse_notify_code {
             $(
@@ -702,13 +671,13 @@ define_notify_code! {
     FUSE_NOTIFY_DELETE = 6,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_notify_poll_wakeup_out {
     pub kh: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_notify_inval_inode_out {
     pub ino: u64,
@@ -716,7 +685,7 @@ pub struct fuse_notify_inval_inode_out {
     pub len: i64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_notify_inval_entry_out {
     pub parent: u64,
@@ -724,7 +693,7 @@ pub struct fuse_notify_inval_entry_out {
     pub padding: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_notify_delete_out {
     pub parent: u64,
@@ -733,7 +702,7 @@ pub struct fuse_notify_delete_out {
     pub padding: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_notify_store_out {
     pub nodeid: u64,
@@ -742,7 +711,7 @@ pub struct fuse_notify_store_out {
     pub padding: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct fuse_notify_retrieve_out {
     pub notify_unique: u64,
@@ -752,7 +721,6 @@ pub struct fuse_notify_retrieve_out {
     pub padding: u32,
 }
 
-#[derive(Debug)]
 #[repr(C)]
 pub struct fuse_notify_retrieve_in {
     pub dummy1: u64,
@@ -763,25 +731,23 @@ pub struct fuse_notify_retrieve_in {
     pub dummy4: u64,
 }
 
-#[derive(Debug)]
-#[repr(C)]
-pub struct cuse_init_in {
-    pub major: u32,
-    pub minor: u32,
-    pub unused: u32,
-    pub flags: u32,
-}
+// #[repr(C)]
+// pub struct cuse_init_in {
+//     pub major: u32,
+//     pub minor: u32,
+//     pub unused: u32,
+//     pub flags: u32,
+// }
 
-#[derive(Debug)]
-#[repr(C)]
-pub struct cuse_init_out {
-    pub major: u32,
-    pub minor: u32,
-    pub unused: u32,
-    pub flags: u32,
-    pub max_read: u32,
-    pub max_write: u32,
-    pub dev_major: u32,
-    pub dev_minor: u32,
-    pub spare: [u32; 10],
-}
+// #[repr(C)]
+// pub struct cuse_init_out {
+//     pub major: u32,
+//     pub minor: u32,
+//     pub unused: u32,
+//     pub flags: u32,
+//     pub max_read: u32,
+//     pub max_write: u32,
+//     pub dev_major: u32,
+//     pub dev_minor: u32,
+//     pub spare: [u32; 10],
+// }

--- a/polyfuse/src/session.rs
+++ b/polyfuse/src/session.rs
@@ -16,7 +16,6 @@ use crate::{
         fuse_notify_poll_wakeup_out,
         fuse_notify_retrieve_out,
         fuse_notify_store_out,
-        fuse_opcode,
     },
     op::{Operation, OperationKind},
     util::as_bytes,
@@ -82,12 +81,6 @@ impl Session {
         let request = io.read_request().await?;
         let header = request.header();
         let arg = request.arg()?;
-
-        tracing::debug!(
-            "Handle a request: unique={}, opcode={:?}",
-            header.unique,
-            fuse_opcode::try_from(header.opcode).ok(),
-        );
 
         let mut cx = Context::new(header, &mut *io);
 

--- a/polyfuse/src/util.rs
+++ b/polyfuse/src/util.rs
@@ -25,3 +25,18 @@ pub(crate) fn make_raw_time(time: SystemTime) -> (u64, u32) {
         .expect("invalid time");
     (duration.as_secs(), duration.subsec_nanos())
 }
+
+pub(crate) trait BuilderExt {
+    fn if_some<T, F>(self, value: Option<T>, f: F) -> Self
+    where
+        Self: Sized,
+        F: FnOnce(Self, T) -> Self,
+    {
+        match value {
+            Some(value) => f(self, value),
+            None => self,
+        }
+    }
+}
+
+impl<T> BuilderExt for T {}


### PR DESCRIPTION
It switches the `Debug` implementations in some public types to the manual, instead of using `#[derive(Debug)]`.
This is also intended to hide the implementation details around the message data from the kernel and to prevent unexpected leakage of the unprocessed data to the user side, and hence it has more than just to improve the readability of debugging log messages.

At the same time, the unused `Debug` derivations and the tracing output inside the library are removed.