### PR TITLE
add LockOwner to protect the raw identifier from the kernel

### DIFF
--- a/polyfuse/src/common.rs
+++ b/polyfuse/src/common.rs
@@ -555,3 +555,20 @@ impl Forget {
         self.0.nlookup
     }
 }
+
+/// The identifier for locking operations.
+#[repr(transparent)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct LockOwner(u64);
+
+impl fmt::Debug for LockOwner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LockOwner {{ .. }}")
+    }
+}
+
+impl LockOwner {
+    pub(crate) const fn from_raw(id: u64) -> Self {
+        Self(id)
+    }
+}

--- a/polyfuse/src/lib.rs
+++ b/polyfuse/src/lib.rs
@@ -30,7 +30,7 @@ mod util;
 
 #[doc(inline)]
 pub use crate::{
-    common::{FileAttr, FileLock, Forget, StatFs},
+    common::{FileAttr, FileLock, Forget, LockOwner, StatFs},
     context::Context,
     dirent::DirEntry,
     fs::Filesystem,


### PR DESCRIPTION
Note: according to　the implementation of the FUSE kernel driver, `lock_owner` contains the value of encrypted `lk_owner_t` using XTEA.