### PR TITLE
Fix bug in memfs example that truncates after every write.

### DIFF
--- a/examples/examples/memfs.rs
+++ b/examples/examples/memfs.rs
@@ -693,7 +693,7 @@ impl MemFS {
         let offset = op.offset() as usize;
         let size = op.size() as usize;
 
-        content.resize(offset + size, 0);
+        content.resize(std::cmp::max(content.len(), offset + size), 0);
 
         use futures::io::AsyncReadExt;
         reader


### PR DESCRIPTION
This is necessary for seeking in modes like 'r+' to work.