### PR TITLE
Make 'Examples' link absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ sudo pacman -S fuse2
 
 ## Resources
 
-* [Examples](./examples)
+* [Examples](https://github.com/ubnt-intrepid/polyfuse/tree/master/examples)
 * [API documentation (docs.rs)](https://docs.rs/polyfuse)
 * [API documentation (master)](https://ubnt-intrepid.github.io/polyfuse/)
 


### PR DESCRIPTION
Using a relative link here doesn't work, e.g. when viewing it rendered at https://github.com/ubnt-intrepid/polyfuse/tree/master/polyfuse. See also https://gitlab.com/crates.rs/crates.rs/-/issues/57.