### PR TITLE
enable -o auto_unmount by default

### DIFF
--- a/crates/polyfuse/src/conn.rs
+++ b/crates/polyfuse/src/conn.rs
@@ -202,7 +202,7 @@ impl Default for MountOptions {
     fn default() -> Self {
         Self {
             options: vec![],
-            auto_unmount: false,
+            auto_unmount: true,
             fusermount_path: None,
             fuse_comm_fd: None,
         }
@@ -222,6 +222,12 @@ impl MountOptions {
         for option in option.split(',').map(|s| s.trim()) {
             self.recognzie_option(option);
         }
+        self
+    }
+
+    #[doc(hidden)] // TODO: dox
+    pub fn auto_unmount(mut self, enabled: bool) -> Self {
+        self.auto_unmount = enabled;
         self
     }
 


### PR DESCRIPTION
If the filesystem does not implement signal handling, the mountpoint
will not appropriately released since the destructor of Connection
is not appropriately called.
To prevent such situation, enabling `auto_unmount` option by default to
ensure that corresponding mountpoint is released at the end of process.

bors: r+
