### PR TITLE
bump polyfuse-tokio to 0.2.3

### DIFF
--- a/crates_deprecated/polyfuse-tokio/Cargo.toml
+++ b/crates_deprecated/polyfuse-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyfuse-tokio"
-version = "0.2.2"
+version = "0.2.3"
 description = "Tokio integration for polyfuse"
 authors = ["Yusuke Sasaki <yusuke.sasaki.nuem@gmail.com>"]
 repository = "https://github.com/ubnt-intrepid/polyfuse.git"
@@ -8,8 +8,10 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 readme = "README.md"
 
+[workspace]
+
 [badges]
-maintenance = { status = "as-is" }
+maintenance = { status = "deprecated" }
 
 [dependencies]
 bytes = "0.5"

--- a/crates_deprecated/polyfuse-tokio/README.md
+++ b/crates_deprecated/polyfuse-tokio/README.md
@@ -25,8 +25,7 @@
 
 `polyfuse-tokio` provides an implementation of the filesystem daemon for running FUSE (Filesystem in Userspace) filesystems on the [`tokio`](https://crates.io/crates/tokio) runtime.
 
-> NOTE: This crate is currently in maintenance mode and will be deprecated after
-> the runtime support for `tokio-0.3`/`mio-0.7` is released.
+> **WARNING:** This crate has been deprecated and no longer maintained.
 
 ## Resources
 

--- a/crates_deprecated/polyfuse-tokio/src/lib.rs
+++ b/crates_deprecated/polyfuse-tokio/src/lib.rs
@@ -1,6 +1,8 @@
-#![doc(html_root_url = "https://docs.rs/polyfuse-tokio/0.2.2")]
+#![doc(html_root_url = "https://docs.rs/polyfuse-tokio/0.2.3")]
 
 //! Tokio integration for `polyfuse`.
+
+#![deprecated(since = "0.2.3", note = "This crate has no longer been in maintenance.")]
 
 #![warn(clippy::checked_conversions)]
 #![deny(


### PR DESCRIPTION
This release is just to announce the end of maintenance for crate users.

bors: r+
