### PR TITLE
fix overflowing the reply buffer for readdir

### DIFF
--- a/crates/polyfuse/src/reply.rs
+++ b/crates/polyfuse/src/reply.rs
@@ -627,9 +627,10 @@ impl ReaddirOut {
             typ,
             name: [],
         };
+        let lenbefore = self.buf.len();
         self.buf.extend_from_slice(dirent.as_bytes());
         self.buf.extend_from_slice(name);
-        self.buf.resize(self.buf.len() + aligned_entry_size, 0);
+        self.buf.resize(lenbefore + aligned_entry_size, 0);
 
         false
     }


### PR DESCRIPTION
the current size of the reply buffer is checked if the to-be-added entry
after aligning fits in the buffer. And if it does the entry get added
and the buffer is resized to (bufferlen + aligned-size-of-entry).

Here the entry-size is included twice, once in bufferlen and once in
aligned-size-of-entry. As as result the initial capacity of the buffer
if overflowing get increased as a result sending back an invalid sized
buffer, which get rejected giving out an "Input/Output Error" from the
kernel to the user.

The path fixes this behaviour by getting the size of before adding the
new entry and extending it by align-size-of-entry