### PR TITLE
allocate the request buffer with u64 alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +567,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "polyfuse"
 version = "0.5.0"
 dependencies = [
+ "bytemuck",
  "either",
  "libc",
  "pin-project-lite",

--- a/crates/polyfuse/Cargo.toml
+++ b/crates/polyfuse/Cargo.toml
@@ -13,6 +13,7 @@ keywords = [ "fuse", "filesystem", "async", "futures" ]
 [dependencies]
 polyfuse-kernel = { version = "0.2.0", path = "../polyfuse-kernel" }
 
+bytemuck = "1.23"
 either = "1"
 libc = "0.2"
 tracing = "0.1"


### PR DESCRIPTION
手っ取り早い解決策として、`Request` 内で保持している `fuse_xxx_in` 用のバッファを `Vec<u64>` に変更する

* add the dependency `bytemuck` to cast `& (mut) [u64]` to `& (mut) [u8]` safely