### PR TITLE
Expose the initialization process of `Connection` from `Session`

### DIFF
--- a/crates/polyfuse/src/conn.rs
+++ b/crates/polyfuse/src/conn.rs
@@ -29,7 +29,8 @@ macro_rules! syscall {
 pub struct Connection {
     fd: RawFd,
     child: Option<Fusermount>,
-    mountopts: MountOptions,
+    mountpoint: PathBuf,
+    _mountopts: MountOptions,
 }
 
 impl Drop for Connection {
@@ -94,7 +95,7 @@ impl Connection {
             let _ = child.wait();
         }
 
-        unmount(&self.mountopts.mountpoint);
+        unmount(&self.mountpoint);
     }
 }
 
@@ -166,24 +167,24 @@ impl io::Write for &Connection {
 
 #[derive(Debug, Clone)]
 pub struct MountOptions {
-    pub(crate) mountpoint: PathBuf,
     options: Vec<String>,
     auto_unmount: bool,
     fusermount_path: Option<PathBuf>,
     fuse_comm_fd: Option<OsString>,
 }
 
-impl MountOptions {
-    pub fn new(mountpoint: impl Into<PathBuf>) -> Self {
+impl Default for MountOptions {
+    fn default() -> Self {
         Self {
-            mountpoint: mountpoint.into(),
             options: vec![],
             auto_unmount: true,
             fusermount_path: None,
             fuse_comm_fd: None,
         }
     }
+}
 
+impl MountOptions {
     pub fn auto_unmount(&mut self, enabled: bool) -> &mut Self {
         self.auto_unmount = enabled;
         self
@@ -216,12 +217,14 @@ impl MountOptions {
         self
     }
 
-    pub fn mount(&self) -> io::Result<Connection> {
-        let (fd, child) = mount(self)?;
+    pub fn mount(&self, mountpoint: impl Into<PathBuf>) -> io::Result<Connection> {
+        let mountpoint = mountpoint.into();
+        let (fd, child) = fusermount(&mountpoint, self)?;
         Ok(Connection {
             fd,
             child,
-            mountopts: self.clone(),
+            mountpoint,
+            _mountopts: self.clone(),
         })
     }
 }
@@ -241,7 +244,10 @@ impl Fusermount {
     }
 }
 
-fn mount(mountopts: &MountOptions) -> io::Result<(RawFd, Option<Fusermount>)> {
+fn fusermount(
+    mountpoint: &Path,
+    mountopts: &MountOptions,
+) -> io::Result<(RawFd, Option<Fusermount>)> {
     let (input, output) = UnixStream::pair()?;
 
     let mut fusermount = Command::new(
@@ -271,7 +277,7 @@ fn mount(mountopts: &MountOptions) -> io::Result<(RawFd, Option<Fusermount>)> {
         fusermount.arg("-o").arg(opts);
     }
 
-    fusermount.arg("--").arg(&mountopts.mountpoint);
+    fusermount.arg("--").arg(mountpoint);
 
     fusermount.env(
         mountopts

--- a/crates/polyfuse/src/lib.rs
+++ b/crates/polyfuse/src/lib.rs
@@ -12,7 +12,7 @@ pub mod op;
 pub mod reply;
 
 pub use crate::{
-    conn::MountOptions,
+    conn::{Connection, MountOptions},
     op::Operation,
     session::{Data, KernelConfig, Notifier, Request, Session},
 };

--- a/crates/polyfuse/src/session.rs
+++ b/crates/polyfuse/src/session.rs
@@ -1,6 +1,6 @@
 use crate::{
     bytes::{Bytes, FillBytes},
-    conn::{Connection, MountOptions},
+    conn::Connection,
     decoder::Decoder,
     op::{DecodeError, Operation},
 };
@@ -292,10 +292,8 @@ impl AsRawFd for Session {
 
 impl Session {
     /// Start a FUSE daemon mount on the specified path.
-    pub fn mount(mountopts: MountOptions, config: KernelConfig) -> io::Result<Self> {
+    pub fn init(conn: Connection, config: KernelConfig) -> io::Result<Self> {
         let KernelConfig { mut init_out } = config;
-
-        let conn = Connection::open(mountopts)?;
 
         init_session(&mut init_out, &conn, &conn)?;
         let bufsize = BUFFER_HEADER_SIZE + init_out.max_write as usize;

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
     ensure!(mountpoint.is_file(), "mountpoint must be a regular file");
 
     // Establish connection to FUSE kernel driver mounted on the specified path.
-    let conn = MountOptions::new(mountpoint).mount()?;
+    let conn = MountOptions::default().mount(mountpoint)?;
 
     // Initialize the FUSE session.
     let session = Session::init(conn, KernelConfig::default())?;

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -14,7 +14,10 @@ fn main() -> Result<()> {
     ensure!(mountpoint.is_file(), "mountpoint must be a regular file");
 
     // Establish connection to FUSE kernel driver mounted on the specified path.
-    let session = Session::mount(MountOptions::new(mountpoint), KernelConfig::default())?;
+    let conn = MountOptions::new(mountpoint).mount()?;
+
+    // Initialize the FUSE session.
+    let session = Session::init(conn, KernelConfig::default())?;
 
     // Receive an incoming FUSE request from the kernel.
     while let Some(req) = session.next_request()? {

--- a/examples/heartbeat-entry/src/main.rs
+++ b/examples/heartbeat-entry/src/main.rs
@@ -48,7 +48,8 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "mountpoint must be a directory");
 
-    let session = Session::mount(MountOptions::new(mountpoint), KernelConfig::default())?;
+    let conn = MountOptions::new(mountpoint).mount()?;
+    let session = Session::init(conn, KernelConfig::default())?;
 
     let fs = {
         let mut root_attr = unsafe { mem::zeroed::<libc::stat>() };

--- a/examples/heartbeat-entry/src/main.rs
+++ b/examples/heartbeat-entry/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "mountpoint must be a directory");
 
-    let conn = MountOptions::new(mountpoint).mount()?;
+    let conn = MountOptions::default().mount(mountpoint)?;
     let session = Session::init(conn, KernelConfig::default())?;
 
     let fs = {

--- a/examples/heartbeat/src/main.rs
+++ b/examples/heartbeat/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_file(), "mountpoint must be a regular file");
 
-    let conn = MountOptions::new(mountpoint).mount()?;
+    let conn = MountOptions::default().mount(mountpoint)?;
     let session = Session::init(conn, KernelConfig::default())?;
 
     let heartbeat = Arc::new(Heartbeat::now());

--- a/examples/heartbeat/src/main.rs
+++ b/examples/heartbeat/src/main.rs
@@ -43,7 +43,8 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_file(), "mountpoint must be a regular file");
 
-    let session = Session::mount(MountOptions::new(mountpoint), KernelConfig::default())?;
+    let conn = MountOptions::new(mountpoint).mount()?;
+    let session = Session::init(conn, KernelConfig::default())?;
 
     let heartbeat = Arc::new(Heartbeat::now());
 

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -24,7 +24,8 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "tmountpoint must be a directory");
 
-    let session = Session::mount(MountOptions::new(mountpoint), KernelConfig::default())?;
+    let conn = MountOptions::new(mountpoint).mount()?;
+    let session = Session::init(conn, KernelConfig::default())?;
 
     let fs = Hello::new();
 

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -24,7 +24,7 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "tmountpoint must be a directory");
 
-    let conn = MountOptions::new(mountpoint).mount()?;
+    let conn = MountOptions::default().mount(mountpoint)?;
     let session = Session::init(conn, KernelConfig::default())?;
 
     let fs = Hello::new();

--- a/examples/memfs/src/main.rs
+++ b/examples/memfs/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "mountpoint must be a directory");
 
-    let conn = MountOptions::new(mountpoint).mount()?;
+    let conn = MountOptions::default().mount(mountpoint)?;
     let session = Session::init(conn, KernelConfig::default())?;
 
     let mut fs = MemFS::new();

--- a/examples/memfs/src/main.rs
+++ b/examples/memfs/src/main.rs
@@ -31,7 +31,8 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "mountpoint must be a directory");
 
-    let session = Session::mount(MountOptions::new(mountpoint), KernelConfig::default())?;
+    let conn = MountOptions::new(mountpoint).mount()?;
+    let session = Session::init(conn, KernelConfig::default())?;
 
     let mut fs = MemFS::new();
 

--- a/examples/passthrough/src/main.rs
+++ b/examples/passthrough/src/main.rs
@@ -48,10 +48,10 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "mountpoint must be a directory");
 
-    let conn = MountOptions::new(mountpoint)
+    let conn = MountOptions::default()
         .mount_option("default_permissions")
         .mount_option("fsname=passthrough")
-        .mount()?;
+        .mount(mountpoint)?;
 
     // TODO: splice read/write
     let session = Session::init(conn, {

--- a/examples/path-through/src/main.rs
+++ b/examples/path-through/src/main.rs
@@ -42,7 +42,8 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "mountpoint must be a directory");
 
-    let session = Session::mount(MountOptions::new(mountpoint), KernelConfig::default())?;
+    let conn = MountOptions::new(mountpoint).mount()?;
+    let session = Session::init(conn, KernelConfig::default())?;
 
     let mut fs = PathThrough::new(source)?;
 

--- a/examples/path-through/src/main.rs
+++ b/examples/path-through/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "mountpoint must be a directory");
 
-    let conn = MountOptions::new(mountpoint).mount()?;
+    let conn = MountOptions::default().mount(mountpoint)?;
     let session = Session::init(conn, KernelConfig::default())?;
 
     let mut fs = PathThrough::new(source)?;

--- a/examples/poll/src/main.rs
+++ b/examples/poll/src/main.rs
@@ -30,7 +30,8 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_file(), "mountpoint must be a regular file");
 
-    let session = Session::mount(MountOptions::new(mountpoint), Default::default())?;
+    let conn = MountOptions::new(mountpoint).mount()?;
+    let session = Session::init(conn, Default::default())?;
 
     let fs = Arc::new(PollFS::new(session.notifier(), wakeup_interval));
 

--- a/examples/poll/src/main.rs
+++ b/examples/poll/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_file(), "mountpoint must be a regular file");
 
-    let conn = MountOptions::new(mountpoint).mount()?;
+    let conn = MountOptions::default().mount(mountpoint)?;
     let session = Session::init(conn, Default::default())?;
 
     let fs = Arc::new(PollFS::new(session.notifier(), wakeup_interval));

--- a/examples/with-tokio/src/main.rs
+++ b/examples/with-tokio/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "mountpoint must be a directory");
 
-    let conn = MountOptions::new(mountpoint).mount()?;
+    let conn = MountOptions::default().mount(mountpoint)?;
     let session = AsyncSession::init(conn, KernelConfig::default()).await?;
 
     let fs = Arc::new(Hello::new());


### PR DESCRIPTION
FUSE セッションの初期化プロセス

1. `/def/fuse` オープンし fd を取得
2. `mount(2)` でマウントポイントと上の fd を紐付ける
3. `opcode=FUSE_INIT` を処理し ABI version 等の設定をネゴシエーション

のうち、1. と 2. は `Connection::open` 部分に集約しているので `Session::mount` から分離可能。
また、3. については `AsyncRead/AsyncWrite` による抽象化によって容易に非同期化が出来る:

```rust
impl<T> Session<T>
where
    T: AsyncRead + AsyncWrite,
{
    async fn init(conn: T, ...) -> io::Result<()> {
        ...
    }
}
```

このPRをマージした後、`Connection` のインスタンスを `Session` が保持するのを止め通信毎に `&conn` で渡すようにする。