### PR TITLE
remove the implemenation of `io::Read`/`io::Write` from `&Connection`

### DIFF
--- a/examples/heartbeat-entry/src/main.rs
+++ b/examples/heartbeat-entry/src/main.rs
@@ -48,8 +48,8 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "mountpoint must be a directory");
 
-    let conn = MountOptions::default().mount(mountpoint).map(Arc::new)?;
-    let session = Session::init(&conn, KernelConfig::default()).map(Arc::new)?;
+    let mut conn = MountOptions::default().mount(mountpoint)?;
+    let session = Session::init(&mut conn, KernelConfig::default()).map(Arc::new)?;
 
     let fs = {
         let mut root_attr = unsafe { mem::zeroed::<libc::stat>() };
@@ -77,24 +77,24 @@ fn main() -> Result<()> {
     // Spawn a task that beats the heart.
     std::thread::spawn({
         let fs = fs.clone();
-        let conn = conn.clone();
+        let mut conn = conn.try_clone()?;
         let notifier = if !no_notify {
             Some(session.clone())
         } else {
             None
         };
         move || -> Result<()> {
-            fs.heartbeat(&conn, notifier)?;
+            fs.heartbeat(&mut conn, notifier)?;
             Ok(())
         }
     });
 
-    while let Some(req) = session.next_request(&conn)? {
+    while let Some(req) = session.next_request(&mut conn)? {
         let fs = fs.clone();
         let session = session.clone();
-        let conn = conn.clone();
+        let mut conn = conn.try_clone()?;
         std::thread::spawn(move || -> Result<()> {
-            fs.handle_request(&session, &conn, &req)?;
+            fs.handle_request(&session, &mut conn, &req)?;
             Ok(())
         });
     }
@@ -121,7 +121,7 @@ struct CurrentFile {
 }
 
 impl Heartbeat {
-    fn heartbeat(&self, conn: &Connection, notifier: Option<Arc<Session>>) -> Result<()> {
+    fn heartbeat(&self, conn: &mut Connection, notifier: Option<Arc<Session>>) -> Result<()> {
         let span = tracing::debug_span!("heartbeat", notify = notifier.is_some());
         let _enter = span.enter();
 
@@ -148,7 +148,12 @@ impl Heartbeat {
         }
     }
 
-    fn handle_request(&self, session: &Session, conn: &Connection, req: &Request) -> Result<()> {
+    fn handle_request(
+        &self,
+        session: &Session,
+        conn: &mut Connection,
+        req: &Request,
+    ) -> Result<()> {
         let span = tracing::debug_span!("handle_request", unique = req.unique());
         let _enter = span.enter();
 

--- a/examples/heartbeat/src/main.rs
+++ b/examples/heartbeat/src/main.rs
@@ -43,8 +43,8 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_file(), "mountpoint must be a regular file");
 
-    let conn = MountOptions::default().mount(mountpoint).map(Arc::new)?;
-    let session = Session::init(&conn, KernelConfig::default()).map(Arc::new)?;
+    let mut conn = MountOptions::default().mount(mountpoint)?;
+    let session = Session::init(&mut conn, KernelConfig::default()).map(Arc::new)?;
 
     let heartbeat = Arc::new(Heartbeat::now());
 
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
     std::thread::spawn({
         let heartbeat = heartbeat.clone();
         let session = session.clone();
-        let conn = conn.clone();
+        let mut conn = conn.try_clone()?;
         let notifier = if !no_notify {
             Some(session.clone())
         } else {
@@ -66,8 +66,10 @@ fn main() -> Result<()> {
 
                 if let Some(ref notifier) = notifier {
                     match notify_kind {
-                        NotifyKind::Store => heartbeat.notify_store(&conn, notifier)?,
-                        NotifyKind::Invalidate => heartbeat.notify_inval_inode(&conn, notifier)?,
+                        NotifyKind::Store => heartbeat.notify_store(&mut conn, notifier)?,
+                        NotifyKind::Invalidate => {
+                            heartbeat.notify_inval_inode(&mut conn, notifier)?
+                        }
                     }
                 }
 
@@ -77,10 +79,10 @@ fn main() -> Result<()> {
     });
 
     // Run the filesystem daemon on the foreground.
-    while let Some(req) = session.next_request(&conn)? {
+    while let Some(req) = session.next_request(&mut conn)? {
         let heartbeat = heartbeat.clone();
         let session = session.clone();
-        let conn = conn.clone();
+        let mut conn = conn.try_clone()?;
 
         std::thread::spawn(move || -> Result<()> {
             let span = tracing::debug_span!("handle request", unique = req.unique());
@@ -95,17 +97,17 @@ fn main() -> Result<()> {
                         let inner = heartbeat.inner.lock().unwrap();
                         let mut out = AttrOut::default();
                         fill_attr(out.attr(), &inner.attr);
-                        session.reply(&conn, &req, out)?;
+                        session.reply(&mut conn, &req, out)?;
                     }
-                    _ => session.reply_error(&conn, &req, libc::ENOENT)?,
+                    _ => session.reply_error(&mut conn, &req, libc::ENOENT)?,
                 },
                 Operation::Open(op) => match op.ino() {
                     ROOT_INO => {
                         let mut out = OpenOut::default();
                         out.keep_cache(true);
-                        session.reply(&conn, &req, out)?;
+                        session.reply(&mut conn, &req, out)?;
                     }
-                    _ => session.reply_error(&conn, &req, libc::ENOENT)?,
+                    _ => session.reply_error(&mut conn, &req, libc::ENOENT)?,
                 },
                 Operation::Read(op) => match op.ino() {
                     ROOT_INO => {
@@ -113,15 +115,15 @@ fn main() -> Result<()> {
 
                         let offset = op.offset() as usize;
                         if offset >= inner.content.len() {
-                            session.reply(&conn, &req, &[])?;
+                            session.reply(&mut conn, &req, &[])?;
                         } else {
                             let size = op.size() as usize;
                             let data = &inner.content.as_bytes()[offset..];
                             let data = &data[..std::cmp::min(data.len(), size)];
-                            session.reply(&conn, &req, data)?;
+                            session.reply(&mut conn, &req, data)?;
                         }
                     }
-                    _ => session.reply_error(&conn, &req, libc::ENOENT)?,
+                    _ => session.reply_error(&mut conn, &req, libc::ENOENT)?,
                 },
                 Operation::NotifyReply(op, mut data) => {
                     let mut retrieves = heartbeat.retrieves.lock().unwrap();
@@ -132,7 +134,7 @@ fn main() -> Result<()> {
                     }
                 }
 
-                _ => session.reply_error(&conn, &req, libc::ENOSYS)?,
+                _ => session.reply_error(&mut conn, &req, libc::ENOSYS)?,
             }
 
             Ok(())
@@ -180,7 +182,7 @@ impl Heartbeat {
         inner.content = content;
     }
 
-    fn notify_store(&self, conn: &Connection, notifier: &Session) -> io::Result<()> {
+    fn notify_store(&self, conn: &mut Connection, notifier: &Session) -> io::Result<()> {
         let inner = self.inner.lock().unwrap();
         let content = &inner.content;
 
@@ -206,7 +208,7 @@ impl Heartbeat {
         Ok(())
     }
 
-    fn notify_inval_inode(&self, conn: &Connection, notifier: &Session) -> io::Result<()> {
+    fn notify_inval_inode(&self, conn: &mut Connection, notifier: &Session) -> io::Result<()> {
         tracing::info!("send notify_invalidate_inode");
         notifier.inval_inode(conn, ROOT_INO, 0, 0)?;
         Ok(())

--- a/examples/passthrough/src/main.rs
+++ b/examples/passthrough/src/main.rs
@@ -48,14 +48,13 @@ fn main() -> Result<()> {
     let mountpoint: PathBuf = args.opt_free_from_str()?.context("missing mountpoint")?;
     ensure!(mountpoint.is_dir(), "mountpoint must be a directory");
 
-    let conn = MountOptions::default()
+    let mut conn = MountOptions::default()
         .mount_option("default_permissions")
         .mount_option("fsname=passthrough")
-        .mount(mountpoint)
-        .map(Arc::new)?;
+        .mount(mountpoint)?;
 
     // TODO: splice read/write
-    let session = Session::init(&conn, {
+    let session = Session::init(&mut conn, {
         let mut config = KernelConfig::default();
         config.export_support(true);
         config.flock_locks(true);
@@ -66,10 +65,10 @@ fn main() -> Result<()> {
 
     let fs = Arc::new(Passthrough::new(source, timeout)?);
 
-    while let Some(req) = session.next_request(&conn)? {
+    while let Some(req) = session.next_request(&mut conn)? {
         let fs = fs.clone();
         let session = session.clone();
-        let conn = conn.clone();
+        let mut conn = conn.try_clone()?;
 
         std::thread::spawn(move || -> Result<()> {
             let span = tracing::debug_span!("handle_request", unique = req.unique());
@@ -83,12 +82,12 @@ fn main() -> Result<()> {
                     match $e {
                         Ok(data) => {
                             tracing::debug!(?data);
-                            session.reply(&conn, &req, data)?;
+                            session.reply(&mut conn, &req, data)?;
                         }
                         Err(err) => {
                             let errno = io_to_errno(err);
                             tracing::debug!(errno = errno);
-                            session.reply_error(&conn, &req, errno)?;
+                            session.reply_error(&mut conn, &req, errno)?;
                         }
                     }
                 };
@@ -155,7 +154,7 @@ fn main() -> Result<()> {
 
                 Operation::Statfs(op) => try_reply!(fs.do_statfs(&op)),
 
-                _ => session.reply_error(&conn, &req, libc::ENOSYS)?,
+                _ => session.reply_error(&mut conn, &req, libc::ENOSYS)?,
             }
 
             Ok(())


### PR DESCRIPTION
同じfdへの書き込みが複数スレッドから発生する場合への対処。
本来は `ioctl(FUSE_DEV_IOC_CLONE)` を使うべきだが（[参考](https://john-millikin.com/the-fuse-protocol#multi-threading)) 、ここでは簡単に `OwnedFd::try_clone` を使用していることに注意。
