### PR TITLE
use I/O abstraction instead of passing `&mut Connection` directly

### DIFF
--- a/examples/heartbeat-entry/src/main.rs
+++ b/examples/heartbeat-entry/src/main.rs
@@ -121,7 +121,7 @@ struct CurrentFile {
 }
 
 impl Heartbeat {
-    fn heartbeat(&self, conn: &mut Connection, notifier: Option<Arc<Session>>) -> Result<()> {
+    fn heartbeat(&self, mut conn: &mut Connection, notifier: Option<Arc<Session>>) -> Result<()> {
         let span = tracing::debug_span!("heartbeat", notify = notifier.is_some());
         let _enter = span.enter();
 
@@ -137,7 +137,7 @@ impl Heartbeat {
             match notifier {
                 Some(ref notifier) if current.nlookup > 0 => {
                     tracing::info!("send notify_inval_entry");
-                    notifier.inval_entry(conn, ROOT_INO, old_filename)?;
+                    notifier.inval_entry(&mut conn, ROOT_INO, old_filename)?;
                 }
                 _ => (),
             }


### PR DESCRIPTION
本来であればここで一気に `AsyncRead` / `AsyncWrite` を使用したいが、差分が大きくなりすぎるので `io::Read` / `io::Write` を使用する。

https://github.com/ubnt-intrepid/polyfuse/pull/173#discussion_r2247708055 での指摘の通り、この抽象化によって FUSE デバイスの実装に柔軟性をもたせることが可能になる。