### PR TITLE
store incoming requests to the queue received during `Session` initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +570,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "polyfuse"
 version = "0.6.0-dev"
 dependencies = [
+ "crossbeam-queue",
  "either",
  "libc",
  "pin-project-lite",

--- a/crates/polyfuse/Cargo.toml
+++ b/crates/polyfuse/Cargo.toml
@@ -14,6 +14,7 @@ keywords = [ "fuse", "filesystem", "async", "futures" ]
 [dependencies]
 polyfuse-kernel = { version = ">=0.2.1", path = "../polyfuse-kernel" }
 
+crossbeam-queue = "0.3.12"
 either = "1"
 libc = "0.2"
 tracing = "0.1"


### PR DESCRIPTION
今までは `FUSE_INIT` が来る前に受信したリクエストに雑に返答した後廃棄していたが、バッファに保持しておき `Session::next_request` 時に取り出すようにした。

`FUSE_INIT` まわりの処理に関する代替案:
* 他の opcode と同格に扱い、セッションの初期化を遅延する
  - `libfuse` や `fuser` などはこの方針を用いている
  - `Session` を共有している場合、設定を書き替える際のロックまわりを考えるのが面倒