### PR TITLE
remove storing incoming requests before FUSE_INIT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,15 +140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,7 +561,6 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "polyfuse"
 version = "0.6.0-dev"
 dependencies = [
- "crossbeam-queue",
  "either",
  "libc",
  "pin-project-lite",

--- a/crates/polyfuse/Cargo.toml
+++ b/crates/polyfuse/Cargo.toml
@@ -14,7 +14,6 @@ keywords = [ "fuse", "filesystem", "async", "futures" ]
 [dependencies]
 polyfuse-kernel = { version = ">=0.2.1", path = "../polyfuse-kernel" }
 
-crossbeam-queue = "0.3.12"
 either = "1"
 libc = "0.2"
 thiserror = "2"


### PR DESCRIPTION
カーネル側の実装によると、

* [`fuse_conn.initialized`](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/fs/fuse/fuse_i.h?h=v6.15.9#n693) フラグがセットされるまで任意のリクエストのenqueueはブロックされる
* このフラグがセットされるのは `FUSE_INIT` のリプライを受け取り、初期化処理が完了した後のみである (`process_init_reply` 関数の最後）

とのことなので、カーネル側の実装に不備がある（パッチが当たってたりなど）場合を除けばセッション初期化が完了する前にリクエストが飛んでくることはないので無視できる。
そこで、#180 で導入した `pending_requests` を再び削除し、ログにエラーを表示させるようにした。
