### PR TITLE
reimplement the session initialization: part 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "polyfuse"
 version = "0.6.0-dev"
 dependencies = [
+ "bitflags 2.9.1",
  "either",
  "libc",
  "pin-project-lite",

--- a/crates/polyfuse/Cargo.toml
+++ b/crates/polyfuse/Cargo.toml
@@ -14,6 +14,7 @@ keywords = [ "fuse", "filesystem", "async", "futures" ]
 [dependencies]
 polyfuse-kernel = { version = ">=0.2.1", path = "../polyfuse-kernel" }
 
+bitflags = "2.9.1"
 either = "1"
 libc = "0.2"
 thiserror = "2"

--- a/crates/polyfuse/src/lib.rs
+++ b/crates/polyfuse/src/lib.rs
@@ -17,5 +17,5 @@ pub mod reply;
 pub use crate::{
     conn::Connection,
     op::Operation,
-    session::{Data, KernelConfig, Request, Session},
+    session::{Data, KernelConfig, KernelFlags, Request, Session},
 };

--- a/examples/passthrough/src/main.rs
+++ b/examples/passthrough/src/main.rs
@@ -9,7 +9,7 @@ use polyfuse::{
     reply::{
         AttrOut, EntryOut, FileAttr, OpenOut, ReaddirOut, Statfs, StatfsOut, WriteOut, XattrOut,
     },
-    Connection, KernelConfig, Operation, Session,
+    Connection, KernelConfig, KernelFlags, Operation, Session,
 };
 
 use anyhow::{ensure, Context as _, Result};
@@ -61,9 +61,9 @@ fn main() -> Result<()> {
     // TODO: splice read/write
     let session = Session::init(&*conn, {
         let mut config = KernelConfig::default();
-        config.export_support(true);
-        config.flock_locks(true);
-        config.writeback_cache(timeout.is_some());
+        config.flags |= KernelFlags::EXPORT_SUPPORT;
+        config.flags |= KernelFlags::FLOCK_LOCKS;
+        config.flags |= KernelFlags::WRITEBACK_CACHE;
         config
     })
     .map(Arc::new)?;


### PR DESCRIPTION
- [x] `KernelConfig` を扱いやすいように定義し直す
- [x] `KernelFlags` を追加し、フラグまわりの処理を単純化する
- [x] `max_write` / `bufsize` まわりの処理を直す
- ~~テストを整理し、カバレッジを改善する~~ → 別PRで対処