### PR TITLE
`Request` まわりの実装を簡略化

### DIFF
--- a/examples/heartbeat.rs
+++ b/examples/heartbeat.rs
@@ -125,11 +125,11 @@ fn main() -> Result<()> {
                     }
                     _ => session.reply_error(&*conn, &req, libc::ENOENT)?,
                 },
-                Operation::NotifyReply(op, mut data) => {
+                Operation::NotifyReply(op) => {
                     let mut retrieves = heartbeat.retrieves.lock().unwrap();
                     if let Some(tx) = retrieves.remove(&op.unique()) {
                         let mut buf = vec![0u8; op.size() as usize];
-                        data.read_exact(&mut buf)?;
+                        (&req).read_exact(&mut buf)?;
                         tx.send(buf).unwrap();
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,5 @@ pub mod reply;
 pub use crate::{
     conn::Connection,
     op::Operation,
-    session::{Data, KernelConfig, KernelFlags, Request, Session},
+    session::{KernelConfig, KernelFlags, Request, Session},
 };


### PR DESCRIPTION
この後 `readv(2)` へのフォールバックや #148 相当のバッファ再利用関連の処理を実装するにあたり、ごちゃごちゃしている部分を簡単にしておく

* フォールバックを見据えて `splice(2)` で使用したパイプを `Option` で保持していたが、現状必要ないのでフラットにした
* `Data` を削除し、`Request` に直接 `io::Read` を実装した
* `Operation` に `Data` を渡すのを止める