### PR TITLE
Make the request buffer reusable

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -26,7 +26,8 @@ fn main() -> Result<()> {
     let session = Session::init(&mut conn, KernelConfig::default())?;
 
     // Receive an incoming FUSE request from the kernel.
-    while let Some(req) = session.next_request(&mut conn)? {
+    let mut req = session.new_request_buffer()?;
+    while session.read_request(&mut conn, &mut req)? {
         match req.operation()? {
             // Dispatch your callbacks to the supported operations...
             Operation::Getattr(op) => getattr(&session, &mut conn, &req, op)?,

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -31,7 +31,8 @@ fn main() -> Result<()> {
 
     let fs = Hello::new(session.clone());
 
-    while let Some(req) = session.next_request(&mut conn)? {
+    let mut req = session.new_request_buffer()?;
+    while session.read_request(&mut conn, &mut req)? {
         match req.operation()? {
             Operation::Lookup(op) => fs.lookup(&mut conn, &req, op)?,
             Operation::Getattr(op) => fs.getattr(&mut conn, &req, op)?,

--- a/examples/memfs.rs
+++ b/examples/memfs.rs
@@ -38,7 +38,8 @@ fn main() -> Result<()> {
 
     let mut fs = MemFS::new(&session, &mut conn);
 
-    while let Some(req) = session.next_request(&mut fs.conn)? {
+    let mut req = session.new_request_buffer()?;
+    while session.read_request(&mut fs.conn, &mut req)? {
         let span = tracing::debug_span!("handle_request", unique = req.unique());
         let _enter = span.enter();
 

--- a/examples/path_through.rs
+++ b/examples/path_through.rs
@@ -49,7 +49,8 @@ fn main() -> Result<()> {
 
     let mut fs = PathThrough::new(source)?;
 
-    while let Some(req) = session.next_request(&mut conn)? {
+    let mut req = session.new_request_buffer()?;
+    while session.read_request(&mut conn, &mut req)? {
         let op = req.operation()?;
         tracing::debug!("handle operation: {:#?}", op);
 

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -77,6 +77,12 @@ impl PipeReader {
         Self(unsafe { OwnedFd::from_raw_fd(fd) })
     }
 
+    pub fn remaining_bytes(&self) -> io::Result<usize> {
+        let mut nbytes: c_int = 0;
+        syscall! { ioctl(self.0.as_raw_fd(), libc::FIONREAD, std::ptr::addr_of_mut!(nbytes)) };
+        Ok(nbytes as usize)
+    }
+
     /// Splice the specified amount of bytes from the pipe buffer to `fd`.
     #[cfg(target_os = "linux")]
     pub fn splice_to(

--- a/src/session.rs
+++ b/src/session.rs
@@ -429,17 +429,17 @@ impl Session {
     where
         T: SpliceRead + io::Write,
     {
-        loop {
-            if request.pipe_reader.remaining_bytes()? > 0 {
-                tracing::warn!(
-                    "The remaining data of request(unique={}) is destroyed",
-                    request.unique()
-                );
-                let (reader, writer) = crate::nix::pipe()?;
-                request.pipe_reader = reader;
-                request.pipe_writer = writer;
-            }
+        if request.pipe_reader.remaining_bytes()? > 0 {
+            tracing::warn!(
+                "The remaining data of request(unique={}) is destroyed",
+                request.unique()
+            );
+            let (reader, writer) = crate::nix::pipe()?;
+            request.pipe_reader = reader;
+            request.pipe_writer = writer;
+        }
 
+        loop {
             match conn.splice_read(&request.pipe_writer, self.request_buffer_size()) {
                 Ok(len) if len < mem::size_of::<fuse_in_header>() => {
                     return Err(io::Error::new(

--- a/src/session.rs
+++ b/src/session.rs
@@ -401,17 +401,46 @@ impl Session {
             + self.config.max_write as usize
     }
 
-    /// Receive an incoming FUSE request from the kernel.
-    pub fn next_request<T>(&self, mut conn: T) -> io::Result<Option<Request>>
+    pub fn new_request_buffer(&self) -> io::Result<Request> {
+        let (pipe_reader, pipe_writer) = crate::nix::pipe()?;
+        Ok(Request {
+            header: fuse_in_header::default(),
+            opcode: None,
+            arg: Vec::with_capacity(self.request_buffer_size() - mem::size_of::<fuse_in_header>()),
+            pipe_reader,
+            pipe_writer,
+        })
+    }
+
+    /// Read an incoming FUSE request from the kernel.
+    pub fn next_request<T>(&self, conn: T) -> io::Result<Option<Request>>
+    where
+        T: SpliceRead + io::Write,
+    {
+        let mut request = self.new_request_buffer()?;
+        if self.read_request(conn, &mut request)? {
+            Ok(Some(request))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn read_request<T>(&self, mut conn: T, request: &mut Request) -> io::Result<bool>
     where
         T: SpliceRead + io::Write,
     {
         loop {
-            // FIXME: 毎回 pipe(2) を呼ばずに再利用する。
-            // 下の splice_read 前に pipe buffer が空になっていることを保証する必要あり
-            let (mut pipe_reader, pipe_writer) = crate::nix::pipe()?;
+            if request.pipe_reader.remaining_bytes()? > 0 {
+                tracing::warn!(
+                    "The remaining data of request(unique={}) is destroyed",
+                    request.unique()
+                );
+                let (reader, writer) = crate::nix::pipe()?;
+                request.pipe_reader = reader;
+                request.pipe_writer = writer;
+            }
 
-            match conn.splice_read(&pipe_writer, self.request_buffer_size()) {
+            match conn.splice_read(&request.pipe_writer, self.request_buffer_size()) {
                 Ok(len) if len < mem::size_of::<fuse_in_header>() => {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
@@ -420,8 +449,8 @@ impl Session {
                 }
 
                 Ok(len) => {
-                    let mut header = fuse_in_header::default();
-                    pipe_reader.read_exact(header.as_mut_bytes())?;
+                    let header = &mut request.header;
+                    request.pipe_reader.read_exact(header.as_mut_bytes())?;
 
                     if len != header.len as usize {
                         return Err(io::Error::new(
@@ -436,8 +465,8 @@ impl Session {
                         }
                         _ => header.len as usize - mem::size_of::<fuse_in_header>(),
                     };
-                    let mut arg = vec![0u8; arglen];
-                    pipe_reader.read_exact(&mut arg[..])?;
+                    request.arg.resize(arglen, 0);
+                    request.pipe_reader.read_exact(&mut request.arg[..])?;
 
                     match fuse_opcode::try_from(header.opcode) {
                         Ok(fuse_opcode::FUSE_INIT) => {
@@ -450,7 +479,7 @@ impl Session {
                             // TODO: FUSE_DESTROY 後にリクエストの読み込みを中断するかどうかを決める
                             tracing::debug!("FUSE_DESTROY received");
                             self.exit();
-                            return Ok(None);
+                            return Ok(false);
                         }
 
                         Ok(fuse_opcode::FUSE_IOCTL)
@@ -473,14 +502,8 @@ impl Session {
                                 header.unique,
                                 header.opcode
                             );
-
-                            break Ok(Some(Request {
-                                header,
-                                opcode,
-                                arg,
-                                pipe_reader,
-                                pipe_writer,
-                            }));
+                            request.opcode = Some(opcode);
+                            break Ok(true);
                         }
                     }
                 }
@@ -488,7 +511,7 @@ impl Session {
                 Err(err) => match err.raw_os_error() {
                     Some(libc::ENODEV) => {
                         tracing::debug!("ENODEV");
-                        return Ok(None);
+                        return Ok(false);
                     }
                     Some(libc::ENOENT) => {
                         tracing::debug!("ENOENT");
@@ -649,10 +672,9 @@ impl Session {
 /// Context about an incoming FUSE request.
 pub struct Request {
     header: fuse_in_header,
-    opcode: fuse_opcode,
+    opcode: Option<fuse_opcode>,
     arg: Vec<u8>,
     pipe_reader: PipeReader,
-    #[allow(dead_code)]
     pipe_writer: PipeWriter,
 }
 
@@ -681,14 +703,13 @@ impl Request {
         self.header.pid
     }
 
-    #[inline]
-    pub fn opcode(&self) -> fuse_opcode {
-        self.opcode
-    }
-
     /// Decode the argument of this request.
     pub fn operation(&self) -> Result<Operation<'_>, crate::op::Error> {
-        Operation::decode(&self.header, self.opcode, &self.arg[..])
+        Operation::decode(
+            &self.header,
+            self.opcode.expect("request is not initialized"),
+            &self.arg[..],
+        )
     }
 }
 


### PR DESCRIPTION
このPRは #148 の引き継ぎであり、これまでリクエスト毎に生成していた `Request` のインスタンスを再利用可能にする。
元々は `readv(2)` における余計なアロケーションを防ぐためのものであったが、`splice(2)` 下でも依然として必要な処置であるため今のうちに実装しておく。

closes #148 .