### PR TITLE
Tidy up implementation around request buffer

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -2,7 +2,7 @@ use crate::{
     bytes::Bytes,
     mount::MountOptions,
     op::{self, Forget},
-    Connection, KernelConfig, Operation, Session,
+    Connection, KernelConfig, Operation, RequestBuffer, Session,
 };
 use libc::{EIO, ENOSYS};
 use std::{ffi::OsStr, io, path::PathBuf, thread};
@@ -147,21 +147,21 @@ pub struct Replied {
 pub struct Request<'req, T: 'req> {
     session: &'req Session,
     conn: &'req Connection,
-    req: &'req crate::request::Request,
+    buf: &'req RequestBuffer,
     arg: T,
 }
 
 impl<T> Request<'_, T> {
     pub fn uid(&self) -> u32 {
-        self.req.uid()
+        self.buf.uid()
     }
 
     pub fn gid(&self) -> u32 {
-        self.req.gid()
+        self.buf.gid()
     }
 
     pub fn pid(&self) -> u32 {
-        self.req.pid()
+        self.buf.pid()
     }
 
     pub fn arg(&self) -> &T {
@@ -173,7 +173,7 @@ impl<T> Request<'_, T> {
         B: Bytes,
     {
         self.session
-            .reply(self.conn, self.req, arg)
+            .reply(self.conn, self.buf, arg)
             .map_err(Error::Reply)?;
         Ok(Replied { _private: () })
     }
@@ -181,21 +181,21 @@ impl<T> Request<'_, T> {
 
 impl io::Read for Request<'_, op::Write<'_>> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.req.read(buf)
+        self.buf.read(buf)
     }
 
     fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
-        self.req.read_vectored(bufs)
+        self.buf.read_vectored(bufs)
     }
 }
 
 impl io::Read for Request<'_, op::NotifyReply<'_>> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.req.read(buf)
+        self.buf.read(buf)
     }
 
     fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
-        self.req.read_vectored(bufs)
+        self.buf.read_vectored(bufs)
     }
 }
 
@@ -228,13 +228,13 @@ where
 
         for _i in 0..num_cpus::get() {
             let worker_conn = conn.try_ioc_clone()?;
-            let mut req = session.new_request_buffer()?;
+            let mut buf = session.new_request_buffer()?;
             scope.spawn(move || -> io::Result<()> {
-                while session.read_request(&worker_conn, &mut req)? {
-                    let span = tracing::debug_span!("handle_request", unique = req.unique());
+                while session.read_request(&worker_conn, &mut buf)? {
+                    let span = tracing::debug_span!("handle_request", unique = buf.unique());
                     let _enter = span.enter();
 
-                    let op = req
+                    let op = buf
                         .operation()
                         .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
                     tracing::debug!(?op);
@@ -249,7 +249,7 @@ where
                             Request {
                                 session,
                                 conn: &worker_conn,
-                                req: &req,
+                                buf: &buf,
                                 arg: $arg,
                             }
                         };
@@ -307,7 +307,7 @@ where
 
                     match res {
                         Err(Error::Reply(err)) => return Err(err),
-                        Err(Error::Code(code)) => session.reply_error(&worker_conn, &req, code)?,
+                        Err(Error::Code(code)) => session.reply_error(&worker_conn, &buf, code)?,
                         Ok(..) => (),
                     }
                 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -147,7 +147,7 @@ pub struct Replied {
 pub struct Request<'req, T: 'req> {
     session: &'req Session,
     conn: &'req Connection,
-    req: &'req crate::session::Request,
+    req: &'req crate::request::Request,
     arg: T,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,6 @@ pub mod reply;
 pub use crate::{
     conn::Connection,
     op::Operation,
-    request::Request,
+    request::RequestBuffer,
     session::{KernelConfig, KernelFlags, Session},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #[macro_use]
 pub mod nix;
 
+mod request;
 mod session;
 
 pub mod bytes;
@@ -18,5 +19,6 @@ pub mod reply;
 pub use crate::{
     conn::Connection,
     op::Operation,
-    session::{KernelConfig, KernelFlags, Request, Session},
+    request::Request,
+    session::{KernelConfig, KernelFlags, Session},
 };

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -63,10 +63,20 @@ pub fn writev(fd: BorrowedFd<'_>, bufs: &[io::IoSlice<'_>]) -> io::Result<usize>
 }
 
 // FIXME: replace with std::io::pipe
-pub fn pipe() -> io::Result<(PipeReader, PipeWriter)> {
+pub fn pipe() -> io::Result<Pipe> {
     let mut fds = [0; 2];
     syscall! { pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC | libc::O_NONBLOCK) };
-    Ok((PipeReader::new(fds[0]), PipeWriter::new(fds[1])))
+    Ok(Pipe {
+        reader: PipeReader::new(fds[0]),
+        writer: PipeWriter::new(fds[1]),
+    })
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Pipe {
+    pub reader: PipeReader,
+    pub writer: PipeWriter,
 }
 
 #[derive(Debug)]

--- a/src/request.rs
+++ b/src/request.rs
@@ -146,7 +146,7 @@ pub enum ReceiveError {
     Interrupted,
 
     #[error(
-        "The opcode `{}' is not recognized by the current version of `polfyfuse`",
+        "The opcode `{}' is not recognized by the current version of `polyfuse`",
         _0
     )]
     UnrecognizedOpcode(u32),

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,176 @@
+use crate::{
+    conn::SpliceRead,
+    nix::{PipeReader, PipeWriter},
+    Operation,
+};
+use libc::{EINTR, ENODEV, ENOENT};
+use polyfuse_kernel::{fuse_in_header, fuse_opcode, fuse_write_in};
+use std::{
+    io::{self, prelude::*},
+    mem,
+};
+use zerocopy::IntoBytes as _;
+
+/// Context about an incoming FUSE request.
+pub struct Request {
+    header: fuse_in_header,
+    opcode: Option<fuse_opcode>,
+    arg: Vec<u8>,
+    pipe_reader: PipeReader,
+    pipe_writer: PipeWriter,
+    bufsize: usize,
+}
+
+impl Request {
+    pub(crate) fn new(bufsize: usize) -> io::Result<Self> {
+        let (pipe_reader, pipe_writer) = crate::nix::pipe()?;
+        Ok(Self {
+            header: fuse_in_header::default(),
+            opcode: None,
+            arg: Vec::with_capacity(bufsize - mem::size_of::<fuse_in_header>()),
+            pipe_reader,
+            pipe_writer,
+            bufsize,
+        })
+    }
+
+    /// Return the unique ID of the request.
+    #[inline]
+    pub fn unique(&self) -> u64 {
+        self.header.unique
+    }
+
+    /// Return the user ID of the calling process.
+    #[inline]
+    pub fn uid(&self) -> u32 {
+        self.header.uid
+    }
+
+    /// Return the group ID of the calling process.
+    #[inline]
+    pub fn gid(&self) -> u32 {
+        self.header.gid
+    }
+
+    /// Return the process ID of the calling process.
+    #[inline]
+    pub fn pid(&self) -> u32 {
+        self.header.pid
+    }
+
+    /// Decode the argument of this request.
+    pub fn operation(&self) -> Result<Operation<'_>, crate::op::Error> {
+        Operation::decode(&self.header, self.opcode(), &self.arg[..])
+    }
+
+    pub(crate) fn clear(&mut self) -> io::Result<()> {
+        if self.pipe_reader.remaining_bytes()? > 0 {
+            tracing::warn!(
+                "The remaining data of request(unique={}) is destroyed",
+                self.unique()
+            );
+            let (reader, writer) = crate::nix::pipe()?;
+            self.pipe_reader = reader;
+            self.pipe_writer = writer;
+        }
+        self.opcode = None;
+        Ok(())
+    }
+
+    pub(crate) fn opcode(&self) -> fuse_opcode {
+        self.opcode.expect("This request buffer is not used")
+    }
+
+    pub(crate) fn try_receive<T>(&mut self, mut conn: T) -> Result<(), ReceiveError>
+    where
+        T: SpliceRead,
+    {
+        let len = conn
+            .splice_read(&self.pipe_writer, self.bufsize)
+            .map_err(|err| {
+                // ref: https://github.com/libfuse/libfuse/blob/fuse-3.10.5/lib/fuse_lowlevel.c#L2865
+                match err.raw_os_error() {
+                    Some(ENODEV) => ReceiveError::Disconnected,
+                    Some(ENOENT) | Some(EINTR) => ReceiveError::Interrupted,
+                    _ => ReceiveError::Fatal(err),
+                }
+            })?;
+
+        if len < mem::size_of::<fuse_in_header>() {
+            Err(ReceiveError::invalid_data(
+                "dequeued request message is too short",
+            ))?
+        }
+
+        self.pipe_reader.read_exact(self.header.as_mut_bytes())?;
+        if len != self.header.len as usize {
+            Err(ReceiveError::invalid_data(
+                "The value in_header.len is mismatched to the result of splice(2)",
+            ))?
+        }
+
+        let opcode = self
+            .header
+            .opcode
+            .try_into()
+            .map_err(|_| ReceiveError::UnrecognizedOpcode(self.header.opcode))?;
+        self.opcode = Some(opcode);
+
+        let arglen = match self.opcode {
+            Some(fuse_opcode::FUSE_WRITE) | Some(fuse_opcode::FUSE_NOTIFY_REPLY) => {
+                mem::size_of::<fuse_write_in>()
+            }
+            _ => self.header.len as usize - mem::size_of::<fuse_in_header>(),
+        };
+        self.arg.resize(arglen, 0);
+        self.pipe_reader.read_exact(&mut self.arg[..])?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReceiveError {
+    #[error("The connection is disconnected")]
+    Disconnected,
+
+    #[error("The read syscall is interrupted")]
+    Interrupted,
+
+    #[error(
+        "The opcode `{}' is not recognized by the current version of `polfyfuse`",
+        _0
+    )]
+    UnrecognizedOpcode(u32),
+
+    #[error("Unrecoverable I/O error: {}", _0)]
+    Fatal(#[from] io::Error),
+}
+
+impl ReceiveError {
+    fn invalid_data<T>(source: T) -> Self
+    where
+        T: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        Self::Fatal(io::Error::new(io::ErrorKind::InvalidData, source))
+    }
+}
+
+impl io::Read for Request {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (&*self).read(buf)
+    }
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        (&*self).read_vectored(bufs)
+    }
+}
+
+impl io::Read for &Request {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (&self.pipe_reader).read(buf)
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        (&self.pipe_reader).read_vectored(bufs)
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -428,7 +428,7 @@ impl Session {
                 }
                 Err(ReceiveError::UnrecognizedOpcode(code)) => {
                     tracing::warn!(
-                        "The opcode `{}' is not recgonized by the current version of polyfuse.",
+                        "The opcode `{}' is not recognized by the current version of polyfuse.",
                         code
                     );
                     write_reply(&mut conn, buf.unique(), ENOSYS, ())?;


### PR DESCRIPTION
* 該当コードを `src/request.rs` に移動
* `fs::Request` との混同を避けつつ、本来の役割と合わせるため名称を `RequestBuffer` に変更

TODOs:
- ~~`FUSE_SPLICE` の有無によるフォールバック処理の実装~~ →別PRで対応
