### PR TITLE
Re-design the decoded filesystem operations

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -59,7 +59,7 @@ fn getattr(
     header: &RequestHeader,
     op: op::Getattr<'_>,
 ) -> io::Result<()> {
-    if op.ino() != NodeID::ROOT {
+    if op.ino != NodeID::ROOT {
         return session.send_reply(conn, header.unique(), ENOENT, ());
     }
 
@@ -96,15 +96,15 @@ fn read(
     header: &RequestHeader,
     op: op::Read<'_>,
 ) -> io::Result<()> {
-    if op.ino() != NodeID::ROOT {
+    if op.ino != NodeID::ROOT {
         return session.send_reply(conn, header.unique(), ENOENT, ());
     }
 
     let mut data: &[u8] = &[];
 
-    let offset = op.offset() as usize;
+    let offset = op.offset as usize;
     if offset < CONTENT.len() {
-        let size = op.size() as usize;
+        let size = op.size as usize;
         data = &CONTENT[offset..];
         data = &data[..std::cmp::min(data.len(), size)];
     }

--- a/examples/heartbeat.rs
+++ b/examples/heartbeat.rs
@@ -147,7 +147,7 @@ impl Filesystem for Heartbeat {
         arg: op::Getattr<'_>,
         mut reply: fs::ReplyAttr<'_>,
     ) -> fs::Result {
-        if arg.ino() != NodeID::ROOT {
+        if arg.ino != NodeID::ROOT {
             Err(ENOENT)?;
         }
         let inner = self.inner.lock().await;
@@ -161,7 +161,7 @@ impl Filesystem for Heartbeat {
         arg: op::Open<'_>,
         mut reply: fs::ReplyOpen<'_>,
     ) -> fs::Result {
-        if arg.ino() != NodeID::ROOT {
+        if arg.ino != NodeID::ROOT {
             Err(ENOENT)?;
         }
         reply.flags(OpenOutFlags::KEEP_CACHE);
@@ -174,18 +174,18 @@ impl Filesystem for Heartbeat {
         arg: op::Read<'_>,
         reply: fs::ReplyData<'_>,
     ) -> fs::Result {
-        if arg.ino() != NodeID::ROOT {
+        if arg.ino != NodeID::ROOT {
             Err(ENOENT)?
         }
 
         let inner = self.inner.lock().await;
 
-        let offset = arg.offset() as usize;
+        let offset = arg.offset as usize;
         if offset >= inner.content.len() {
             return reply.send(());
         }
 
-        let size = arg.size() as usize;
+        let size = arg.size as usize;
         let data = &inner.content.as_bytes()[offset..];
         let data = &data[..std::cmp::min(data.len(), size)];
         reply.send(data)
@@ -196,9 +196,9 @@ impl Filesystem for Heartbeat {
         arg: op::NotifyReply<'_>,
         mut data: impl io::Read,
     ) -> io::Result<()> {
-        if let Some((_, original)) = self.retrieves.remove(&arg.unique()) {
+        if let Some((_, original)) = self.retrieves.remove(&arg.unique) {
             let data = {
-                let mut buf = vec![0u8; arg.size() as usize];
+                let mut buf = vec![0u8; arg.size as usize];
                 data.read_exact(&mut buf)?;
                 buf
             };

--- a/examples/heartbeat_entry.rs
+++ b/examples/heartbeat_entry.rs
@@ -145,13 +145,13 @@ impl Filesystem for Heartbeat {
         arg: op::Lookup<'_>,
         mut reply: fs::ReplyEntry<'_>,
     ) -> fs::Result {
-        if arg.parent() != NodeID::ROOT {
+        if arg.parent != NodeID::ROOT {
             Err(ENOTDIR)?;
         }
 
         let mut current = self.current.lock().await;
 
-        if arg.name().as_bytes() == current.filename.as_bytes() {
+        if arg.name.as_bytes() == current.filename.as_bytes() {
             reply.ino(self.file_attr.ino);
             reply.attr(&self.file_attr);
             reply.ttl_entry(self.ttl);
@@ -181,7 +181,7 @@ impl Filesystem for Heartbeat {
         arg: op::Getattr<'_>,
         mut reply: fs::ReplyAttr<'_>,
     ) -> fs::Result {
-        let attr = match arg.ino() {
+        let attr = match arg.ino {
             NodeID::ROOT => &self.root_attr,
             FILE_INO => &self.file_attr,
             _ => Err(ENOENT)?,
@@ -198,7 +198,7 @@ impl Filesystem for Heartbeat {
         arg: op::Read<'_>,
         reply: fs::ReplyData<'_>,
     ) -> fs::Result {
-        match arg.ino() {
+        match arg.ino {
             NodeID::ROOT => Err(EISDIR)?,
             FILE_INO => reply.send(()),
             _ => Err(ENOENT)?,
@@ -211,10 +211,10 @@ impl Filesystem for Heartbeat {
         arg: op::Readdir<'_>,
         mut reply: fs::ReplyDir<'_>,
     ) -> fs::Result {
-        if arg.ino() != NodeID::ROOT {
+        if arg.ino != NodeID::ROOT {
             Err(ENOTDIR)?;
         }
-        if arg.offset() > 0 {
+        if arg.offset > 0 {
             return reply.send();
         }
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -108,8 +108,8 @@ impl Filesystem for Hello {
         op: op::Lookup<'_>,
         mut reply: fs::ReplyEntry<'_>,
     ) -> fs::Result {
-        match op.parent() {
-            NodeID::ROOT if op.name().as_bytes() == HELLO_FILENAME.as_bytes() => {
+        match op.parent {
+            NodeID::ROOT if op.name.as_bytes() == HELLO_FILENAME.as_bytes() => {
                 reply.attr(&self.hello_attr());
                 reply.ino(HELLO_INO);
                 reply.ttl_attr(TTL);
@@ -126,7 +126,7 @@ impl Filesystem for Hello {
         op: op::Getattr<'_>,
         mut reply: fs::ReplyAttr<'_>,
     ) -> fs::Result {
-        let attr = match op.ino() {
+        let attr = match op.ino {
             NodeID::ROOT => self.root_attr(),
             HELLO_INO => self.hello_attr(),
             _ => Err(ENOENT)?,
@@ -143,7 +143,7 @@ impl Filesystem for Hello {
         op: op::Read<'_>,
         reply: fs::ReplyData<'_>,
     ) -> fs::Result {
-        match op.ino() {
+        match op.ino {
             HELLO_INO => (),
             NodeID::ROOT => Err(EISDIR)?,
             _ => Err(ENOENT)?,
@@ -151,9 +151,9 @@ impl Filesystem for Hello {
 
         let mut data: &[u8] = &[];
 
-        let offset = op.offset() as usize;
+        let offset = op.offset as usize;
         if offset < HELLO_CONTENT.len() {
-            let size = op.size() as usize;
+            let size = op.size as usize;
             data = &HELLO_CONTENT[offset..];
             data = &data[..std::cmp::min(data.len(), size)];
         }
@@ -167,11 +167,11 @@ impl Filesystem for Hello {
         op: op::Readdir<'_>,
         mut reply: fs::ReplyDir<'_>,
     ) -> fs::Result {
-        if op.ino() != NodeID::ROOT {
+        if op.ino != NodeID::ROOT {
             Err(ENOTDIR)?
         }
 
-        for (i, entry) in self.dir_entries().skip(op.offset() as usize) {
+        for (i, entry) in self.dir_entries().skip(op.offset as usize) {
             let full = reply.push_entry(
                 entry.name.as_ref(), //
                 entry.ino,

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -550,7 +550,7 @@ impl Worker {
             Operation::Flush(op) => fs.flush(req, op, ReplyUnit::new(sender)).await,
             Operation::Opendir(op) => fs.opendir(req, op, ReplyOpen::new(sender)).await,
             Operation::Readdir(op) => {
-                let capacity = op.size() as usize;
+                let capacity = op.size as usize;
                 fs.readdir(req, op, ReplyDir::new(sender, capacity)).await
             }
             Operation::Releasedir(op) => fs.releasedir(req, op, ReplyUnit::new(sender)).await,
@@ -577,7 +577,7 @@ impl Worker {
                 return Ok(());
             }
             Operation::Interrupt(op) => {
-                tracing::warn!("interrupted(unique={})", op.unique());
+                tracing::warn!("interrupted(unique={})", op.unique);
                 // TODO: handle interrupt requests.
                 Err(ENOSYS.into())
             }


### PR DESCRIPTION
* 各 op が `fuse_in_header` や `fuse_XXX_in` への参照を保持するのではなく、解析後の結果を持つようにする
