### PR TITLE
add support for privileged mount

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ either = "1"
 libc = "0.2"
 num_cpus = "1.17"
 polyfuse-kernel = { version = "0.3.0-dev", path = "crates/polyfuse-kernel" }
-rustix = { version = "1", features = [ "fs", "net", "param", "pipe", "process" ] }
+rustix = { version = "1", features = [ "fs", "mount", "net", "param", "pipe", "process", "thread" ] }
 thiserror = "2"
 tokio = { version = ">=1.8.4", features = [ "fs", "net", "rt" ] }
 tracing = "0.1"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
 use polyfuse::{
-    mount::{mount_unprivileged, MountOptions},
+    mount::{mount, MountOptions},
     op::{self, Operation},
     request::{FallbackBuf, RequestBuf as _, RequestHeader},
     session::{KernelConfig, Session},
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
 
     // Establish connection to FUSE kernel driver mounted on the specified path.
     let mountopts = MountOptions::new();
-    let (mut conn, fusermount) = mount_unprivileged(mountpoint.into(), &mountopts)?;
+    let (mut conn, fusermount) = mount(&mountpoint.into(), &mountopts)?;
 
     // Initialize the FUSE session.
     let mut session = Session::new();

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
 use polyfuse::{
-    mount::{mount_unpriv, MountOptions},
+    mount::{mount_unprivileged, MountOptions},
     op::{self, Operation},
     request::{FallbackBuf, RequestBuf as _, RequestHeader},
     session::{KernelConfig, Session},
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
 
     // Establish connection to FUSE kernel driver mounted on the specified path.
     let mountopts = MountOptions::new();
-    let (mut conn, fusermount) = mount_unpriv(mountpoint.into(), &mountopts)?;
+    let (mut conn, fusermount) = mount_unprivileged(mountpoint.into(), &mountopts)?;
 
     // Initialize the FUSE session.
     let mut session = Session::new();

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
 use polyfuse::{
-    mount::{mount, MountOptions},
+    mount::{mount_unpriv, MountOptions},
     op::{self, Operation},
     request::{FallbackBuf, RequestBuf as _, RequestHeader},
     session::{KernelConfig, Session},
@@ -29,7 +29,8 @@ fn main() -> Result<()> {
     ensure!(mountpoint.is_file(), "mountpoint must be a regular file");
 
     // Establish connection to FUSE kernel driver mounted on the specified path.
-    let (mut conn, fusermount) = mount(mountpoint, MountOptions::default())?;
+    let mountopts = MountOptions::new();
+    let (mut conn, fusermount) = mount_unpriv(mountpoint.into(), &mountopts)?;
 
     // Initialize the FUSE session.
     let mut session = Session::new();

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
 
     // Establish connection to FUSE kernel driver mounted on the specified path.
     let mountopts = MountOptions::new();
-    let (mut conn, fusermount) = mount(&mountpoint.into(), &mountopts)?;
+    let (mut conn, mount) = mount(&mountpoint.into(), &mountopts)?;
 
     // Initialize the FUSE session.
     let mut session = Session::new();
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
         };
     }
 
-    fusermount.unmount()?;
+    mount.unmount()?;
 
     Ok(())
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -6,7 +6,7 @@ use rustix::{
 };
 use std::{ffi::CStr, io, os::unix::prelude::*};
 
-const FUSE_DEV_NAME: &CStr = c"/dev/fuse";
+pub(crate) const FUSE_DEV_NAME: &CStr = c"/dev/fuse";
 
 // FIXME: move to polyfuse-kernel
 const FUSE_DEV_IOC_MAGIC: u8 = 229;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,7 +1,7 @@
 use crate::{
     bytes::Bytes,
     conn::Connection,
-    mount::{unprivileged::Fusermount, MountOptions},
+    mount::{Mount, MountOptions},
     op::{self, Forget, Operation},
     reply,
     request::{FallbackBuf, RequestBuf, RequestHeader, SpliceBuf},
@@ -375,7 +375,7 @@ pub type ReplyLseek<'req> = reply::ReplyLseek<ReplySender<'req>>;
 pub struct Daemon {
     global: Arc<Global>,
     config: KernelConfig,
-    fusermount: Fusermount,
+    fusermount: Mount,
     join_set: JoinSet<io::Result<()>>,
 }
 
@@ -385,7 +385,7 @@ impl Daemon {
         mountopts: MountOptions,
         mut config: KernelConfig,
     ) -> io::Result<Self> {
-        let (conn, fusermount) = crate::mount::mount_unprivileged(mountpoint.into(), &mountopts)?;
+        let (conn, fusermount) = crate::mount::mount(&mountpoint.into(), &mountopts)?;
 
         let mut session = Session::new();
         session.init(&conn, &mut config)?;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,7 +1,7 @@
 use crate::{
     bytes::Bytes,
     conn::Connection,
-    mount::{unpriv::Fusermount, MountOptions},
+    mount::{unprivileged::Fusermount, MountOptions},
     op::{self, Forget, Operation},
     reply,
     request::{FallbackBuf, RequestBuf, RequestHeader, SpliceBuf},
@@ -385,7 +385,7 @@ impl Daemon {
         mountopts: MountOptions,
         mut config: KernelConfig,
     ) -> io::Result<Self> {
-        let (conn, fusermount) = crate::mount::mount_unpriv(mountpoint.into(), &mountopts)?;
+        let (conn, fusermount) = crate::mount::mount_unprivileged(mountpoint.into(), &mountopts)?;
 
         let mut session = Session::new();
         session.init(&conn, &mut config)?;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,7 +1,7 @@
 use crate::{
     bytes::Bytes,
     conn::Connection,
-    mount::{Fusermount, MountOptions},
+    mount::{unpriv::Fusermount, MountOptions},
     op::{self, Forget, Operation},
     reply,
     request::{FallbackBuf, RequestBuf, RequestHeader, SpliceBuf},
@@ -15,12 +15,13 @@ use rustix::{
     process::Pid,
 };
 use std::{
+    borrow::Cow,
     ffi::OsStr,
     future::Future,
     io,
     num::NonZeroUsize,
     panic,
-    path::PathBuf,
+    path::Path,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Weak,
@@ -380,11 +381,11 @@ pub struct Daemon {
 
 impl Daemon {
     pub async fn mount(
-        mountpoint: PathBuf,
+        mountpoint: impl Into<Cow<'static, Path>>,
         mountopts: MountOptions,
         mut config: KernelConfig,
     ) -> io::Result<Self> {
-        let (conn, fusermount) = crate::mount::mount(mountpoint, mountopts)?;
+        let (conn, fusermount) = crate::mount::mount_unpriv(mountpoint.into(), &mountopts)?;
 
         let mut session = Session::new();
         session.init(&conn, &mut config)?;

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,9 +1,9 @@
-pub mod unpriv;
+pub mod unprivileged;
 
 use bitflags::{bitflags, bitflags_match};
 use std::{borrow::Cow, fmt, path::Path};
 
-pub use unpriv::mount_unpriv;
+pub use unprivileged::mount_unprivileged;
 
 // refs:
 // * https://github.com/libfuse/libfuse/blob/fuse-3.10.5/lib/mount.c

--- a/src/mount/privileged.rs
+++ b/src/mount/privileged.rs
@@ -1,0 +1,118 @@
+use crate::{
+    conn::FUSE_DEV_NAME,
+    mount::{MountOptions, PrivilegedOptions},
+    Connection,
+};
+use rustix::{
+    fs::{Gid, Mode, OFlags, Uid},
+    io::Errno,
+    mount::{MountFlags, UnmountFlags},
+    process::{getgid, getuid},
+    thread::CapabilitySet,
+};
+use std::{borrow::Cow, ffi::CString, io, os::unix::prelude::*, path::Path};
+
+#[derive(Debug)]
+#[must_use]
+pub struct Mount {
+    mountpoint: Cow<'static, Path>,
+    unmounted: bool,
+}
+
+impl Mount {
+    fn unmount_(&mut self) -> io::Result<()> {
+        if !self.unmounted {
+            rustix::mount::unmount(
+                &*self.mountpoint,
+                UnmountFlags::FORCE | UnmountFlags::DETACH,
+            )?;
+            self.unmounted = true;
+        }
+        Ok(())
+    }
+
+    pub fn unmount(mut self) -> io::Result<()> {
+        self.unmount_()
+    }
+}
+
+impl Drop for Mount {
+    fn drop(&mut self) {
+        let _ = self.unmount_();
+    }
+}
+
+/// Establish a connection with the FUSE kernel driver in privileged mode.
+pub fn mount_privileged(
+    mountpoint: Cow<'static, Path>,
+    mountopts: &MountOptions,
+) -> io::Result<(Connection, Mount)> {
+    let caps = rustix::thread::capabilities(None)?;
+    if !caps.effective.contains(CapabilitySet::SYS_ADMIN) {
+        return Err(Errno::PERM.into());
+    }
+
+    let stat = rustix::fs::stat(&*mountpoint)?;
+
+    let fd = rustix::fs::open(FUSE_DEV_NAME, OFlags::RDWR | OFlags::CLOEXEC, Mode::empty())?;
+
+    let PrivilegedOptions { fstype, opts } =
+        mountopts.privileged_options(Some(&prefix(&fd, stat.st_mode, getuid(), getgid())));
+
+    let source = mountopts
+        .fsname
+        .as_deref()
+        .or(mountopts.subtype.as_deref())
+        .unwrap_or(
+            FUSE_DEV_NAME
+                .to_str()
+                .expect("DEV_NAME must be a valid UTF-8 string"),
+        );
+
+    let data = Some(CString::new(opts).expect("invalid opts"));
+
+    rustix::mount::mount(
+        source,
+        &*mountpoint,
+        fstype,
+        MountFlags::empty(),
+        data.as_deref(),
+    )?;
+
+    Ok((
+        Connection::from(fd),
+        Mount {
+            mountpoint,
+            unmounted: false,
+        },
+    ))
+}
+
+fn prefix(fd: &impl AsFd, mode: u32, uid: Uid, gid: Gid) -> String {
+    let root_mode = mode & libc::S_IFMT;
+    format!(
+        "fd={},rootmode={:o},user_id={},group_id={}",
+        fd.as_fd().as_raw_fd(),
+        root_mode,
+        uid,
+        gid
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::ManuallyDrop;
+
+    #[test]
+    fn test_prefix() {
+        let fd = unsafe { ManuallyDrop::new(OwnedFd::from_raw_fd(42)) };
+        let mode = libc::S_IFDIR;
+        let uid = Uid::from_raw(1001);
+        let gid = Gid::from_raw(422);
+        assert_eq!(
+            prefix(&*fd, mode, uid, gid),
+            "fd=42,rootmode=40000,user_id=1001,group_id=422"
+        );
+    }
+}

--- a/src/mount/privileged.rs
+++ b/src/mount/privileged.rs
@@ -22,10 +22,7 @@ pub struct SysMount {
 impl SysMount {
     fn unmount_(&mut self) -> io::Result<()> {
         if !self.unmounted {
-            rustix::mount::unmount(
-                &*self.mountpoint,
-                UnmountFlags::FORCE | UnmountFlags::DETACH,
-            )?;
+            rustix::mount::unmount(&*self.mountpoint, UnmountFlags::DETACH)?;
             self.unmounted = true;
         }
         Ok(())

--- a/src/mount/unpriv.rs
+++ b/src/mount/unpriv.rs
@@ -1,0 +1,151 @@
+use super::{MountFlags, MountOptions};
+use crate::conn::Connection;
+use rustix::{
+    io::FdFlags,
+    net::{RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags},
+};
+use std::{
+    borrow::Cow,
+    io,
+    mem::{ManuallyDrop, MaybeUninit},
+    os::unix::{net::UnixStream, prelude::*},
+    path::Path,
+    process::{Child, Command},
+};
+
+const FUSERMOUNT_PROG: &str = "/usr/bin/fusermount";
+const FUSE_COMMFD_ENV: &str = "_FUSE_COMMFD";
+
+/// The object that manages the mount status of the FUSE daemon.
+#[derive(Debug)]
+pub struct Fusermount {
+    child: Option<PipedChild>,
+    mountpoint: Cow<'static, Path>,
+    fusermount_path: Cow<'static, Path>,
+}
+
+impl Fusermount {
+    /// Unmount the filesystem.
+    pub fn unmount(mut self) -> io::Result<()> {
+        self.unmount_()
+    }
+
+    fn unmount_(&mut self) -> io::Result<()> {
+        if let Some(child) = self.child.take() {
+            // この場合、fusermount の終了にともない umount(2) が暗黙的に呼び出される。
+            // なので、fd受信用の UnixStream を閉じてバックグラウンドの fusermount を終了する。
+            child.wait()?;
+        } else {
+            // fusermount は fd を受信した直後に終了しているので、明示的に umount(2) を呼ぶ必要がある。
+            // 非特権プロセスなので `fusermount -u /path/to/mountpoint` を呼ぶことで間接的にアンマウントを行う
+            let _st = Command::new(&*self.fusermount_path)
+                .args(["-u", "-q", "-z", "--"])
+                .arg(&*self.mountpoint)
+                .status()?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Fusermount {
+    fn drop(&mut self) {
+        let _ = self.unmount_();
+    }
+}
+
+#[derive(Debug)]
+struct PipedChild {
+    child: Child,
+    input: UnixStream,
+}
+
+impl PipedChild {
+    fn wait(mut self) -> io::Result<()> {
+        drop(self.input);
+        let _st = self.child.wait()?;
+        Ok(())
+    }
+}
+
+/// Establish a connection with the FUSE kernel driver in non-privileged mode.
+pub fn mount_unpriv(
+    mountpoint: Cow<'static, Path>,
+    mountopts: &MountOptions,
+) -> io::Result<(Connection, Fusermount)> {
+    tracing::debug!("Mount information:");
+    tracing::debug!("  mountpoint: {:?}", mountpoint);
+    tracing::debug!("  opts: {:?}", mountopts);
+
+    let fusermount_path = mountopts
+        .fusermount_path
+        .clone()
+        .unwrap_or(Path::new(FUSERMOUNT_PROG).into());
+
+    let mut fusermount = Command::new(&*fusermount_path);
+
+    let opts = mountopts.to_string();
+    if !opts.is_empty() {
+        fusermount.arg("-o").arg(opts);
+    }
+
+    fusermount.arg("--").arg(&*mountpoint);
+
+    let (input, output) = UnixStream::pair()?;
+
+    fusermount.env(FUSE_COMMFD_ENV, output.as_raw_fd().to_string());
+
+    unsafe {
+        let output = ManuallyDrop::new(output);
+        fusermount.pre_exec(move || {
+            rustix::io::fcntl_setfd(&*output, FdFlags::empty()).map_err(Into::into)
+        });
+    }
+
+    let child = fusermount.spawn()?;
+
+    let fd = receive_fd(&input)?;
+
+    let mut child = Some(PipedChild { child, input });
+    if !mountopts.flags.contains(MountFlags::AUTO_UNMOUNT) {
+        // When auto_unmount is not specified, `fusermount` exits immediately
+        // after sending the file descriptor and thus we need to wait until
+        // the command is exited.
+        let child = child.take().unwrap();
+        child.wait()?;
+    }
+
+    Ok((
+        Connection::from(fd),
+        Fusermount {
+            child,
+            mountpoint: mountpoint.clone(),
+            fusermount_path,
+        },
+    ))
+}
+
+fn receive_fd(reader: &UnixStream) -> io::Result<OwnedFd> {
+    let mut buf = [0u8; 1];
+    let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
+    let mut cmsg_buffer = RecvAncillaryBuffer::new(&mut space);
+
+    let _msg = rustix::net::recvmsg(
+        reader,
+        &mut [io::IoSliceMut::new(&mut buf[..])],
+        &mut cmsg_buffer,
+        RecvFlags::empty(),
+    );
+
+    let fd = cmsg_buffer
+        .drain()
+        .flat_map(|msg| match msg {
+            RecvAncillaryMessage::ScmRights(mut fds) => fds.next(),
+            _ => None,
+        })
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "recv_fd"))?;
+
+    rustix::io::fcntl_setfd(&fd, FdFlags::CLOEXEC)?;
+
+    Ok(fd)
+}

--- a/src/mount/unprivileged.rs
+++ b/src/mount/unprivileged.rs
@@ -96,7 +96,7 @@ pub fn mount_unprivileged(
     fusermount.stdout(Stdio::piped());
     fusermount.stderr(Stdio::piped());
 
-    let opts = mountopts.to_string();
+    let opts = mountopts.unprivileged_options();
     if !opts.is_empty() {
         fusermount.arg("-o").arg(opts);
     }

--- a/src/mount/unprivileged.rs
+++ b/src/mount/unprivileged.rs
@@ -82,7 +82,7 @@ pub fn mount(
     if !mountpoint.exists() {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
-            "The specified mountpoint is not exist",
+            "The specified mountpoint does not exist",
         ));
     }
 

--- a/src/mount/unprivileged.rs
+++ b/src/mount/unprivileged.rs
@@ -70,8 +70,9 @@ impl Drop for Fusermount {
 }
 
 /// Establish a connection with the FUSE kernel driver in non-privileged mode.
-pub fn mount_unprivileged(
-    mountpoint: Cow<'static, Path>,
+#[allow(clippy::ptr_arg)]
+pub fn mount(
+    mountpoint: &Cow<'static, Path>,
     mountopts: &MountOptions,
 ) -> io::Result<(Connection, Fusermount)> {
     tracing::debug!("Mount information:");
@@ -101,7 +102,7 @@ pub fn mount_unprivileged(
         fusermount.arg("-o").arg(opts);
     }
 
-    fusermount.arg("--").arg(&*mountpoint);
+    fusermount.arg("--").arg(&**mountpoint);
 
     let (input, output) = UnixStream::pair()?;
 
@@ -129,7 +130,7 @@ pub fn mount_unprivileged(
             tracing::error!("The child `fusermount` exists with failure");
             tracing::error!("  stdout: {:?}", String::from_utf8_lossy(&output.stdout));
             tracing::error!("  stderr: {:?}", String::from_utf8_lossy(&output.stderr));
-            umount(&mountpoint, &fusermount_path)?;
+            umount(mountpoint, &fusermount_path)?;
             return Err(Errno::INVAL.into());
         }
 

--- a/src/mount/unprivileged.rs
+++ b/src/mount/unprivileged.rs
@@ -70,7 +70,7 @@ impl Drop for Fusermount {
 }
 
 /// Establish a connection with the FUSE kernel driver in non-privileged mode.
-pub fn mount_unpriv(
+pub fn mount_unprivileged(
     mountpoint: Cow<'static, Path>,
     mountopts: &MountOptions,
 ) -> io::Result<(Connection, Fusermount)> {


### PR DESCRIPTION
特権マウントを実装しつつ、全体的に整理する

* `fusermount` への fallback は実装しない
* `/etc/mtab` の書き込みは行わない
  - libfuse で `IGNORE_MTAB` が常に有効化されているような状態