### PR TITLE
Simple fix for build on musl/alpine to work

### DIFF
--- a/crates/polyfuse-kernel/src/lib.rs
+++ b/crates/polyfuse-kernel/src/lib.rs
@@ -112,7 +112,7 @@ pub const FUSE_COMPAT_22_INIT_OUT_SIZE: usize = 24;
 pub const CUSE_INIT_INFO_MAX: u32 = 4096;
 
 // Device ioctls
-pub const FUSE_DEV_IOC_CLONE: u64 = libc::_IOR::<u32>(229, 0);
+pub const FUSE_DEV_IOC_CLONE: u64 = libc::_IOR::<u32>(229, 0) as u64;
 
 #[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable)]
 #[repr(C)]


### PR DESCRIPTION
```
error[E0308]: mismatched types
   --> crates/polyfuse-kernel/src/lib.rs:115:37
    |
115 | pub const FUSE_DEV_IOC_CLONE: u64 = libc::_IOR::<u32>(229, 0);
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found `i32`
  
```