### PR TITLE
remove the check of header PID in try_receive

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -90,23 +90,28 @@ impl RequestHeader {
     /// Return the user ID of the calling process.
     #[inline]
     pub fn uid(&self) -> Option<Uid> {
-        self.is_special_request()
-            .then(|| Uid::from_raw(self.raw.uid))
+        if self.is_special_request() {
+            return None;
+        }
+        Some(Uid::from_raw(self.raw.uid))
     }
 
     /// Return the group ID of the calling process.
     #[inline]
     pub fn gid(&self) -> Option<Gid> {
-        self.is_special_request()
-            .then(|| Gid::from_raw(self.raw.gid))
+        if self.is_special_request() {
+            return None;
+        }
+        Some(Gid::from_raw(self.raw.gid))
     }
 
     /// Return the process ID of the calling process.
     #[inline]
     pub fn pid(&self) -> Option<Pid> {
-        self.is_special_request()
-            .then(|| Pid::from_raw(self.raw.pid as i32))
-            .flatten()
+        if self.is_special_request() {
+            return None;
+        }
+        Pid::from_raw(self.raw.pid as i32)
     }
 
     fn arg_len(&self) -> usize {


### PR DESCRIPTION
* `FUSE_RELEASE` / `FUSE_RELEASEDIR` では `fuse_args.force = true` かつ `fuse_args.nocred = true` が指定されている ([ref](https://elixir.bootlin.com/linux/v6.16.11/source/fs/fuse/file.c#L325-L326))
* `fuse_simple_{request,background}` で上の条件が満たされるとき `fuse_args.pid` は設定されない
* 他の opcode での挙動は不明だが、条件次第で同じ状況になる可能性がある
* 安全のため、Pid の変換チェックを除外しておく